### PR TITLE
Add option to turn on/off verbose log at runtime.

### DIFF
--- a/end2end-test-examples/gcs/build.gradle
+++ b/end2end-test-examples/gcs/build.gradle
@@ -62,7 +62,7 @@ sourceSets {
 task run(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'io.grpc.gcs.TestMain'
-    jvmArgs = ['-Djava.util.logging.config.file=./logging.properties']
+    //jvmArgs = ['-Djava.util.logging.config.file=./logging.properties']
     //jvmArgs = ['-Xlint:deprecation']
     //jvmArgs = ['-Djava.security.debug=provider']
 }

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/Args.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/Args.java
@@ -33,6 +33,7 @@ public class Args {
   final int threads;
   final int flowControlWindow;
   final boolean autoWindow;
+  final boolean verboseLog;
 
   Args(String[] args) throws ArgumentParserException {
     ArgumentParser parser =
@@ -57,6 +58,7 @@ public class Args {
     parser.addArgument("--threads").type(Integer.class).setDefault(1);
     parser.addArgument("--window").type(Integer.class).setDefault(0);
     parser.addArgument("--auto").type(Boolean.class).setDefault(false);
+    parser.addArgument("--verboseLog").type(Boolean.class).setDefault(false);
 
     Namespace ns = parser.parseArgs(args);
 
@@ -77,5 +79,6 @@ public class Args {
     threads = ns.getInt("threads");
     flowControlWindow = ns.getInt("window");
     autoWindow = ns.getBoolean("auto");
+    verboseLog = ns.getBoolean("verboseLog");
   }
 }

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/TestMain.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/TestMain.java
@@ -7,12 +7,14 @@ import static io.grpc.gcs.Args.CLIENT_YOSHI;
 
 import com.google.gson.Gson;
 import io.grpc.netty.shaded.io.grpc.netty.InternalHandlerSettings;
+import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.security.Security;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.LogManager;
 import java.util.logging.Logger;
 import org.conscrypt.Conscrypt;
 
@@ -72,6 +74,9 @@ public class TestMain {
 
   public static void main(String[] args) throws Exception {
     Args a = new Args(args);
+    if (a.verboseLog) {
+      LogManager.getLogManager().readConfiguration(new FileInputStream("logging.properties"));
+    }
     if (a.conscrypt) {
       Security.insertProviderAt(Conscrypt.newProvider(), 1);
     }


### PR DESCRIPTION
We can now enable verbose log by using `--verboseLog=true`, and the default value is false.