### PR TITLE
Add result-table

### DIFF
--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/Args.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/Args.java
@@ -34,6 +34,7 @@ public class Args {
   final int flowControlWindow;
   final boolean autoWindow;
   final boolean verboseLog;
+  final boolean verboseResult;
 
   Args(String[] args) throws ArgumentParserException {
     ArgumentParser parser =
@@ -59,6 +60,7 @@ public class Args {
     parser.addArgument("--window").type(Integer.class).setDefault(0);
     parser.addArgument("--auto").type(Boolean.class).setDefault(false);
     parser.addArgument("--verboseLog").type(Boolean.class).setDefault(false);
+    parser.addArgument("--verboseResult").type(Boolean.class).setDefault(false);
 
     Namespace ns = parser.parseArgs(args);
 
@@ -80,5 +82,6 @@ public class Args {
     flowControlWindow = ns.getInt("window");
     autoWindow = ns.getBoolean("auto");
     verboseLog = ns.getBoolean("verboseLog");
+    verboseResult = ns.getBoolean("verboseResult");
   }
 }

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GcsioClient.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GcsioClient.java
@@ -41,7 +41,7 @@ public class GcsioClient {
             .build();
   }
 
-  public void startCalls(List<Long> results) throws InterruptedException, IOException {
+  public void startCalls(ResultTable results) throws InterruptedException, IOException {
     if (args.threads == 1) {
       switch (args.method) {
         case METHOD_READ:
@@ -98,7 +98,7 @@ public class GcsioClient {
     }
   }
 
-  private void makeMediaRequest(List<Long> results) throws IOException {
+  private void makeMediaRequest(ResultTable results) throws IOException {
     GoogleCloudStorageFileSystem gcsfs = new GoogleCloudStorageFileSystem(creds,
         GoogleCloudStorageFileSystemOptions.builder()
             .setCloudStorageOptions(gcsOpts)
@@ -121,13 +121,13 @@ public class GcsioClient {
       buff.clear();
       readChannel.close();
       //logger.info("time cost for reading bytes: " + dur + "ms");
-      results.add(dur);
+      results.reportResult(dur);
     }
 
     gcsfs.close();
   }
 
-  private void makeWriteRequest(List<Long> results, int idx) throws IOException, InterruptedException {
+  private void makeWriteRequest(ResultTable results, int idx) throws IOException, InterruptedException {
     GoogleCloudStorageFileSystem gcsfs = new GoogleCloudStorageFileSystem(creds,
         GoogleCloudStorageFileSystemOptions.builder()
             .setCloudStorageOptions(gcsOpts)
@@ -148,14 +148,14 @@ public class GcsioClient {
       writeChannel.close();
       // write operation is async, need to call close() to wait for finish.
       long dur = System.currentTimeMillis() - start;
-      results.add(dur);
+      results.reportResult(dur);
       Thread.sleep(1000); // Avoid request limit for updating a single object
     }
 
     gcsfs.close();
   }
 
-  private void makeRandomMediaRequest(List<Long> results) throws IOException {
+  private void makeRandomMediaRequest(ResultTable results) throws IOException {
     GoogleCloudStorageFileSystem gcsfs = new GoogleCloudStorageFileSystem(creds,
         GoogleCloudStorageFileSystemOptions.builder()
             .setCloudStorageOptions(gcsOpts)
@@ -180,7 +180,7 @@ public class GcsioClient {
         logger.warning("Got remaining bytes: " + buff.remaining());
       }
       logger.info("time cost for reading bytes: " + dur + "ms");
-      results.add(dur);
+      results.reportResult(dur);
     }
     reader.close();
 

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GrpcClient.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GrpcClient.java
@@ -97,7 +97,7 @@ public class GrpcClient {
     }
   }
 
-  public void startCalls(List<Long> results) throws InterruptedException {
+  public void startCalls(ResultTable results) throws InterruptedException {
     ManagedChannel channel = this.channels[0];
     if (args.threads == 1) {
       try {
@@ -161,7 +161,7 @@ public class GrpcClient {
     }
   }
 
-  private void makeMediaRequest(ManagedChannel channel, List<Long> results) {
+  private void makeMediaRequest(ManagedChannel channel, ResultTable results) {
     StorageGrpc.StorageBlockingStub blockingStub =
         StorageGrpc.newBlockingStub(channel).withCallCredentials(
             MoreCallCredentials.from(creds.createScoped(SCOPE)));
@@ -180,11 +180,11 @@ public class GrpcClient {
         GetObjectMediaResponse res = resIterator.next();
       }
       long dur = System.currentTimeMillis() - start;
-      results.add(dur);
+      results.reportResult(dur);
     }
   }
 
-  private void makeRandomMediaRequest(ManagedChannel channel, List<Long> results) {
+  private void makeRandomMediaRequest(ManagedChannel channel, ResultTable results) {
     StorageGrpc.StorageBlockingStub blockingStub =
         StorageGrpc.newBlockingStub(channel).withCallCredentials(
             MoreCallCredentials.from(creds.createScoped(SCOPE)));
@@ -215,11 +215,11 @@ public class GrpcClient {
       logger.info("time cost for getObjectMedia: " + dur + "ms");
       logger.info("total iterations: " + itr);
       logger.info("start pos: " + offset + ", read lenth: " + buffSize + ", total KB read: " + bytesRead / 1024);
-      results.add(dur);
+      results.reportResult(dur);
     }
   }
 
-  private void makeInsertRequest(ManagedChannel channel, List<Long> results, int idx) throws InterruptedException {
+  private void makeInsertRequest(ManagedChannel channel, ResultTable results, int idx) throws InterruptedException {
     StorageGrpc.StorageStub asyncStub = StorageGrpc.newStub(channel).withCallCredentials(
         MoreCallCredentials.from(creds.createScoped(SCOPE)));
     if (args.host.equals(Args.DEFAULT_HOST)) {
@@ -252,7 +252,7 @@ public class GrpcClient {
         public void onCompleted() {
           finishLatch.countDown();
           long dur = System.currentTimeMillis() - start;
-          results.add(dur);
+          results.reportResult(dur);
         }
       };
 

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/HttpClient.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/HttpClient.java
@@ -33,7 +33,7 @@ public class HttpClient {
     this.client = StorageOptions.getDefaultInstance().getService();
   }
 
-  public void startCalls(List<Long> results) throws InterruptedException, IOException {
+  public void startCalls(ResultTable results) throws InterruptedException, IOException {
     if (args.threads == 0) {
       switch (args.method) {
         case METHOD_READ:
@@ -68,7 +68,7 @@ public class HttpClient {
     }
   }
 
-  public void makeMediaRequest(List<Long> results) {
+  public void makeMediaRequest(ResultTable results) {
     BlobId blobId = BlobId.of(args.bkt, args.obj);
     for (int i = 0; i < args.calls; i++) {
       long start = System.currentTimeMillis();
@@ -78,11 +78,11 @@ public class HttpClient {
       long dur = System.currentTimeMillis() - start;
       //logger.info("time cost for readAllBytes: " + dur + "ms");
       //logger.info("total KB received: " + content.length/1024);
-      results.add(dur);
+      results.reportResult(dur);
     }
   }
 
-  public void makeRandomMediaRequest(List<Long> results) throws IOException {
+  public void makeRandomMediaRequest(ResultTable results) throws IOException {
     Random r = new Random();
 
     BlobId blobId = BlobId.of(args.bkt, args.obj);
@@ -101,12 +101,12 @@ public class HttpClient {
       logger.info("total KB received: " + buff.position()/1024);
       logger.info("time cost for random reading: " + dur + "ms");
       buff.clear();
-      results.add(dur);
+      results.reportResult(dur);
     }
     reader.close();
   }
 
-  public void makeInsertRequest(List<Long> results) {
+  public void makeInsertRequest(ResultTable results) {
     int totalBytes = args.size * 1024;
     byte[] data = new byte[totalBytes];
     BlobId blobId = BlobId.of(args.bkt, args.obj);
@@ -118,7 +118,7 @@ public class HttpClient {
       );
       long dur = System.currentTimeMillis() - start;
       logger.info("time cost for creating blob: " + dur + "ms");
-      results.add(dur);
+      results.reportResult(dur);
     }
   }
 }

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/ResultTable.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/ResultTable.java
@@ -1,0 +1,103 @@
+package io.grpc.gcs;
+
+import com.google.gson.Gson;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+import org.conscrypt.Conscrypt;
+
+
+public class ResultTable {
+  private Args args;
+  private Long startTime;
+  private Long endTime;
+  private List<Long> results;
+
+  public ResultTable(Args args) {
+    this.args = args;
+    this.results = new ArrayList<>();
+  }
+
+  public void start() {
+    synchronized (this) {
+      startTime = System.currentTimeMillis();
+    }
+  }
+
+  public void stop() {
+    synchronized (this) {
+      endTime = System.currentTimeMillis();  
+    }
+  }
+
+  public void reportResult(long duration) {
+    int ord;
+    synchronized (this) {
+      results.add(duration);
+      ord = results.size();
+    }
+    if (this.args.verboseResult) {
+      System.out.format("### Result: ord=%d elapsed=%d\n", ord, duration);
+      System.out.flush();
+    }
+  }
+
+  private static class BenchmarkResult {
+    public Long min, p50, p90, p99, p999;
+    public double qps;
+  }
+
+  public void printResult() throws IOException {
+    synchronized (this) {
+      if (results.size() == 0) return;
+      Collections.sort(results);
+      int n = results.size();
+      double totalSeconds = 0;
+      long totalDur = endTime - startTime;
+      for (Long ms : results) {
+        totalSeconds += ms / 1000.0;
+      }
+
+      Gson gson = new Gson();
+      BenchmarkResult benchmarkResult = new BenchmarkResult();
+      benchmarkResult.min = results.get(0);
+      benchmarkResult.p50 = results.get((int) (n * 0.05));
+      benchmarkResult.p90 = results.get((int) (n * 0.90));
+      benchmarkResult.p99 = results.get((int) (n * 0.99));
+      benchmarkResult.p999 = results.get((int) (n * 0.999));
+      benchmarkResult.qps = n / totalSeconds;
+      if (!args.latencyFilename.isEmpty()) {
+        FileWriter writer = new FileWriter(args.latencyFilename);
+        gson.toJson(benchmarkResult, writer);
+        writer.close();
+      }
+      System.out.println(String.format(
+          "****** Test Results [client: %s, method: %s, size: %d, threads: %d, dp: %s, calls: %d]: \n"
+              + "\t\tMin\tp5\tp10\tp25\tp50\tp75\tp90\tp99\tMax\tTotal\n"
+              + "  Time(ms)\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+          args.client,
+          args.method,
+          args.size,
+          args.threads,
+          args.dp,
+          n,
+          results.get(0),
+          results.get((int) (n * 0.05)),
+          results.get((int) (n * 0.1)),
+          results.get((int) (n * 0.25)),
+          results.get((int) (n * 0.50)),
+          results.get((int) (n * 0.75)),
+          results.get((int) (n * 0.90)),
+          results.get((int) (n * 0.99)),
+          results.get(n - 1),
+          totalDur
+      ));
+    } 
+  }
+}

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/TestMain.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/TestMain.java
@@ -21,57 +21,6 @@ import org.conscrypt.Conscrypt;
 public class TestMain {
   private static final Logger logger = Logger.getLogger(TestMain.class.getName());
 
-  private static class BenchmarkResult {
-    public Long min, p50, p90, p99, p999;
-    public double qps;
-  }
-
-  private static void printResult(List<Long> results, long totalDur, Args args)
-      throws IOException {
-    if (results.size() == 0) return;
-    Collections.sort(results);
-    int n = results.size();
-    double totalSeconds = 0;
-    for (Long ms : results) {
-      totalSeconds += ms / 1000.0;
-    }
-
-    Gson gson = new Gson();
-    BenchmarkResult benchmarkResult = new BenchmarkResult();
-    benchmarkResult.min = results.get(0);
-    benchmarkResult.p50 = results.get((int) (n * 0.05));
-    benchmarkResult.p90 = results.get((int) (n * 0.90));
-    benchmarkResult.p99 = results.get((int) (n * 0.99));
-    benchmarkResult.p999 = results.get((int) (n * 0.999));
-    benchmarkResult.qps = n / totalSeconds;
-    if (!args.latencyFilename.isEmpty()) {
-      FileWriter writer = new FileWriter(args.latencyFilename);
-      gson.toJson(benchmarkResult, writer);
-      writer.close();
-    }
-    System.out.println(String.format(
-        "****** Test Results [client: %s, method: %s, size: %d, threads: %d, dp: %s, calls: %d]: \n"
-            + "\t\tMin\tp5\tp10\tp25\tp50\tp75\tp90\tp99\tMax\tTotal\n"
-            + "  Time(ms)\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
-        args.client,
-        args.method,
-        args.size,
-        args.threads,
-        args.dp,
-        n,
-        results.get(0),
-        results.get((int) (n * 0.05)),
-        results.get((int) (n * 0.1)),
-        results.get((int) (n * 0.25)),
-        results.get((int) (n * 0.50)),
-        results.get((int) (n * 0.75)),
-        results.get((int) (n * 0.90)),
-        results.get((int) (n * 0.99)),
-        results.get(n - 1),
-        totalDur
-    ));
-  }
-
   public static void main(String[] args) throws Exception {
     Args a = new Args(args);
     if (a.verboseLog) {
@@ -84,38 +33,37 @@ public class TestMain {
       InternalHandlerSettings.enable(true);
       InternalHandlerSettings.autoWindowOn(true);
     }
-    List<Long> results = new ArrayList<>();
-    if (a.threads > 1) results = Collections.synchronizedList(results);
+    ResultTable results = new ResultTable(a);
     long start = 0;
     long totalDur = 0;
     switch (a.client) {
       case CLIENT_YOSHI:
         HttpClient httpClient = new HttpClient(a);
-        start = System.currentTimeMillis();
+        results.start();
         httpClient.startCalls(results);
-        totalDur = System.currentTimeMillis() - start;
+        results.stop();
         break;
       case CLIENT_GCSIO_HTTP:
         GcsioClient gcsioHttpClient = new GcsioClient(a, false);
-        start = System.currentTimeMillis();
+        results.start();
         gcsioHttpClient.startCalls(results);
-        totalDur = System.currentTimeMillis() - start;
+        results.stop();
         break;
       case CLIENT_GCSIO_GRPC:
         GcsioClient gcsioGrpcClient = new GcsioClient(a, true);
-        start = System.currentTimeMillis();
+        results.start();
         gcsioGrpcClient.startCalls(results);
-        totalDur = System.currentTimeMillis() - start;
+        results.stop();
         break;
       case CLIENT_GRPC:
         GrpcClient grpcClient = new GrpcClient(a);
-        start = System.currentTimeMillis();
+        results.start();
         grpcClient.startCalls(results);
-        totalDur = System.currentTimeMillis() - start;
+        results.stop();
         break;
       default:
         logger.warning("Please provide --client");
     }
-    printResult(results, totalDur, a);
+    results.printResult();
   }
 }


### PR DESCRIPTION
Refactored it to have a dedicated result collection class, `ResultTable` which enables to implement `verboseResult`, which is helpful to understand how long each request takes and provide a hook for the script to kick in or out.