### PR TITLE
Add support for BatchEcho

### DIFF
--- a/end2end-test-examples/echo-client/README.md
+++ b/end2end-test-examples/echo-client/README.md
@@ -39,6 +39,8 @@ Per sec Payload = 0.07 MB (exact amount of KB = 10000)
 
 `--resSize`: Set response payload size in KB.
 
+`--resType`: Set the response type. If 0, the client sends a `EchoWithResponseSize` rpc. If [1,2,3], the client sends a `BatchEcho` and sets the `response_type` with this value in `BatchEchoRequest`. 
+
 `--reqComp`: gRPC compression algorithm to use for request. Currently only supports `gzip`.
 
 `--resComp`: gRPC compression algorithm to use for response. Currently only supports `gzip`.

--- a/end2end-test-examples/echo-client/src/main/java/io/grpc/echo/Args.java
+++ b/end2end-test-examples/echo-client/src/main/java/io/grpc/echo/Args.java
@@ -27,6 +27,7 @@ public class Args {
   final int qps;
   final int reqSize;
   final int resSize;
+  final int resType;
   final PoissonDistribution distrib;
 
   Args(String[] args) throws ArgumentParserException {
@@ -53,6 +54,7 @@ public class Args {
     parser.addArgument("--qps").type(Integer.class).setDefault(0);
     parser.addArgument("--reqSize").type(Integer.class).setDefault(1);
     parser.addArgument("--resSize").type(Integer.class).setDefault(1);
+    parser.addArgument("--resType").type(Integer.class).setDefault(0);
 
     Namespace ns = parser.parseArgs(args);
 
@@ -74,6 +76,7 @@ public class Args {
     qps = ns.getInt("qps");
     reqSize = ns.getInt("reqSize");
     resSize = ns.getInt("resSize");
+    resType = ns.getInt("resType");
     distrib = (qps > 0) ? new PoissonDistribution(1000/qps) : null;
   }
 }

--- a/end2end-test-examples/echo-client/src/main/proto/echo.proto
+++ b/end2end-test-examples/echo-client/src/main/proto/echo.proto
@@ -16,6 +16,15 @@ message EchoResponse {
   string echoed_string = 1;
 }
 
+message BatchEchoRequest {
+  string echo_msg = 1;
+  int32 response_type = 2;
+}
+
+message BatchEchoResponse {
+  repeated EchoResponse echo_responses = 1;
+}
+
 message EchoWithResponseSizeRequest {
   string echo_msg = 1;
   int32 response_size = 2;
@@ -32,14 +41,14 @@ service GrpcCloudapi {
   // A simple echo RPC returns the input string
   rpc Echo(EchoRequest) returns (EchoResponse) {
     option (google.api.http) = {
-      get: "/v1/{string_to_echo}"
+      get: "/v1/echo/{string_to_echo}"
     };
   }
 
   // A simple echo RPC receives a custom response size
   rpc EchoWithResponseSize(EchoWithResponseSizeRequest) returns (EchoResponse) {
     option (google.api.http) = {
-      get: "/v1/{response_size}"
+      get: "/v1/echo/{echo_msg}/{response_size}"
     };
   }
 
@@ -49,4 +58,12 @@ service GrpcCloudapi {
       get: "/v1/stream/{message_count}/{message_interval}"
     };
   }
+
+  // RPC to get a list of echo responses
+  rpc BatchEcho(BatchEchoRequest) returns (BatchEchoResponse) {
+    option (google.api.http) = {
+      get: "/v1/batch/{echo_msg}/{response_type}"
+    };
+  }
+
 }


### PR DESCRIPTION
As required by Uber, the service has been updated to support `BatchEcho`, which returns a new `BatchEchoResponse` that contains a list of `EchoResponse`.  This PR is to add the support on client side accordingly.