### PR TITLE
Fix a bug to set conscrypt by default

### DIFF
--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/TestMain.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/TestMain.java
@@ -20,7 +20,7 @@ public class TestMain {
       LogManager.getLogManager().readConfiguration(new FileInputStream("logging.properties"));
     }
     if (a.conscrypt) {
-      Security.insertProviderAt(Conscrypt.newProvider(), 1);
+      Security.insertProviderAt(Conscrypt.newProviderBuilder().provideTrustManager(false).build(), 1);
     }
     ResultTable results = new ResultTable(a);
     long start = 0;


### PR DESCRIPTION
This is a workaround of conscrypt having a breaking change. Without this, this option doesn't work with the latest Conscrypt (e.g. 2.4) on CFE.