### PR TITLE
More options; conscrypt_notm and checksum

### DIFF
--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/Args.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/Args.java
@@ -28,6 +28,7 @@ public class Args {
   final int buffSize;
   final String method;
   final boolean conscrypt;
+  final boolean conscrypt_notm;
   final String client;
   final String latencyFilename;
   final int threads;
@@ -53,6 +54,7 @@ public class Args {
     parser.addArgument("--buffSize").type(Integer.class).setDefault(0);
     parser.addArgument("--method").type(String.class).setDefault(METHOD_READ);
     parser.addArgument("--conscrypt").type(Boolean.class).setDefault(false);
+    parser.addArgument("--conscrypt_notm").type(Boolean.class).setDefault(false);
     parser.addArgument("--client").type(String.class).setDefault(CLIENT_GRPC);
     parser.addArgument("--latencyFilename").type(String.class).setDefault("");
     parser.addArgument("--threads").type(Integer.class).setDefault(1);
@@ -74,6 +76,7 @@ public class Args {
     buffSize = ns.getInt("buffSize");
     method = ns.getString("method");
     conscrypt = ns.getBoolean("conscrypt");
+    conscrypt_notm = ns.getBoolean("conscrypt_notm");
     client = ns.getString("client");
     latencyFilename = ns.getString("latencyFilename");
     threads = ns.getInt("threads");

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/Args.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/Args.java
@@ -33,6 +33,7 @@ public class Args {
   final String latencyFilename;
   final int threads;
   final int flowControlWindow;
+  final boolean checksum;
   final boolean verboseLog;
   final boolean verboseResult;
 
@@ -59,6 +60,7 @@ public class Args {
     parser.addArgument("--latencyFilename").type(String.class).setDefault("");
     parser.addArgument("--threads").type(Integer.class).setDefault(1);
     parser.addArgument("--window").type(Integer.class).setDefault(0);
+    parser.addArgument("--checksum").type(Boolean.class).setDefault(false);
     parser.addArgument("--verboseLog").type(Boolean.class).setDefault(false);
     parser.addArgument("--verboseResult").type(Boolean.class).setDefault(false);
 
@@ -81,6 +83,7 @@ public class Args {
     latencyFilename = ns.getString("latencyFilename");
     threads = ns.getInt("threads");
     flowControlWindow = ns.getInt("window");
+    checksum = ns.getBoolean("checksum");
     verboseLog = ns.getBoolean("verboseLog");
     verboseResult = ns.getBoolean("verboseResult");
   }

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GcsioClient.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GcsioClient.java
@@ -9,6 +9,7 @@ import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
+import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
@@ -16,12 +17,12 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.List;
 import java.util.logging.Logger;
+import java.util.Random;
 
 public class GcsioClient {
   private static final Logger logger = Logger.getLogger(GcsioClient.class.getName());
@@ -38,6 +39,8 @@ public class GcsioClient {
     this.gcsOpts = GoogleCloudStorageOptions.builder()
             .setAppName("weiranf-app")
             .setGrpcEnabled(grpcEnabled)
+            .setReadChannelOptions(GoogleCloudStorageReadOptions.builder().setGrpcChecksumsEnabled(args.checksum).build())
+            .setWriteChannelOptions(AsyncWriteChannelOptions.builder().setGrpcChecksumsEnabled(args.checksum).build())
             .build();
   }
 
@@ -168,7 +171,7 @@ public class GcsioClient {
 
     URI uri = URI.create("gs://" + args.bkt + "/" + args.obj);
     
-    GoogleCloudStorageReadOptions readOpts = GoogleCloudStorageReadOptions.builder().build();
+    GoogleCloudStorageReadOptions readOpts = gcsOpts.getReadChannelOptions();
 
     SeekableByteChannel reader = gcsfs.open(uri, readOpts);
     for (int i = 0; i < args.calls; i++) {

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/TestMain.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/TestMain.java
@@ -21,6 +21,8 @@ public class TestMain {
     }
     if (a.conscrypt) {
       Security.insertProviderAt(Conscrypt.newProvider(), 1);
+    } else if (a.conscrypt_notm) {
+      Security.insertProviderAt(Conscrypt.newProviderBuilder().provideTrustManager(false).build(), 1);
     }
     ResultTable results = new ResultTable(a);
     long start = 0;


### PR DESCRIPTION
Added two options;
- `conscrypt_notm`: Enabling conscrypt without trustmanager
- `checksum`: Controlling checksum calculation for gcsio