### PR TITLE
Revert "Made GCS use 2.2.0 instead of the head"

### DIFF
--- a/end2end-test-examples/gcs/build.gradle
+++ b/end2end-test-examples/gcs/build.gradle
@@ -9,7 +9,7 @@ version '1.0-SNAPSHOT'
 
 sourceCompatibility = 1.8
 
-def gcsioVersion = '2.2.0'
+def gcsioVersion = '2.2.1-SNAPSHOT'
 def grpcVersion = '1.35.0'
 def protobufVersion = '3.12.0'
 def protocVersion = protobufVersion


### PR DESCRIPTION
Reverts GoogleCloudPlatform/grpc-gcp-java#65 to verify b/179719287