### PR TITLE
Add optional metrics.

### DIFF
--- a/grpc-gcp/build.gradle
+++ b/grpc-gcp/build.gradle
@@ -13,6 +13,7 @@ repositories {
     mavenLocal()
 }
 
+version = '0.0.1-METRICS'
 group = 'com.google.cloud'
 description = 'GRPC-GCP-Extension Java'
 sourceCompatibility = '1.8'
@@ -21,13 +22,15 @@ def grpcVersion = '1.36.0'
 def protobufVersion = '3.12.0'
 def protocVersion = '3.12.0'
 def spannerVersion = '6.1.0'
+def opencensusVersion = '0.28.0'
 
 dependencies {
+    implementation "com.google.protobuf:protobuf-java:${protobufVersion}"
+    implementation "com.google.protobuf:protobuf-java-util:${protobufVersion}"
     implementation "io.grpc:grpc-netty-shaded:${grpcVersion}"
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
-    implementation "com.google.protobuf:protobuf-java:${protobufVersion}"
-    implementation "com.google.protobuf:protobuf-java-util:${protobufVersion}"
+    implementation "io.opencensus:opencensus-api:${opencensusVersion}"
 
     compileOnly "org.apache.tomcat:annotations-api:6.0.53" // necessary for Java 9+
 
@@ -91,9 +94,9 @@ publishing {
             from components.java
             artifact javadocJar
             artifact sourcesJar
-            groupId = 'grpc.gcp.extension'
-            artifactId = 'grpc-gcp-extension'
-            version = '1.0.0'
+            groupId = group
+            artifactId = 'grpc-gcp'
+            version = version
             pom {
                 name = "gRPC extension library for Google Cloud Library"
                 url = 'https://github.com/GoogleCloudPlatform/grpc-gcp-java/tree/master/grpc-gcp'

--- a/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannelBuilder.java
+++ b/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannelBuilder.java
@@ -33,11 +33,13 @@ public class GcpManagedChannelBuilder extends ForwardingChannelBuilder<GcpManage
 
   private final ManagedChannelBuilder delegate;
   private int poolSize = 0;
+  private GcpManagedChannelOptions options;
 
   @VisibleForTesting ApiConfig apiConfig;
 
   private GcpManagedChannelBuilder(ManagedChannelBuilder delegate) {
     this.delegate = delegate;
+    this.options = new GcpManagedChannelOptions();
   }
 
   private ApiConfig parseConfigFromJsonFile(File file) {
@@ -86,6 +88,13 @@ public class GcpManagedChannelBuilder extends ForwardingChannelBuilder<GcpManage
     return this;
   }
 
+  public GcpManagedChannelBuilder withOptions(GcpManagedChannelOptions options) {
+    if (options != null) {
+      this.options = options;
+    }
+    return this;
+  }
+
   /** Returns the delegated {@code ManagedChannelBuilder}. */
   @Override
   protected ManagedChannelBuilder<?> delegate() {
@@ -98,6 +107,6 @@ public class GcpManagedChannelBuilder extends ForwardingChannelBuilder<GcpManage
    */
   @Override
   public ManagedChannel build() {
-    return new GcpManagedChannel(delegate, apiConfig, poolSize);
+    return new GcpManagedChannel(delegate, apiConfig, poolSize, options);
   }
 }

--- a/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannelBuilder.java
+++ b/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannelBuilder.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 public class GcpManagedChannelBuilder extends ForwardingChannelBuilder<GcpManagedChannelBuilder> {
 
@@ -88,7 +89,7 @@ public class GcpManagedChannelBuilder extends ForwardingChannelBuilder<GcpManage
     return this;
   }
 
-  public GcpManagedChannelBuilder withOptions(GcpManagedChannelOptions options) {
+  public GcpManagedChannelBuilder withOptions(@Nullable GcpManagedChannelOptions options) {
     if (options != null) {
       this.options = options;
     }

--- a/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannelOptions.java
+++ b/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannelOptions.java
@@ -58,6 +58,34 @@ public class GcpManagedChannelOptions {
     /**
      * Sets the metrics configuration for the {@link GcpManagedChannel}.
      *
+     * <p>If a {@link MetricRegistry} is provided in {@link GcpMetricsOptions} then the
+     * GcpManagedChannel will emit metrics using that registry. The metrics options also allow to
+     * set up labels (tags) and a prefix for metrics names.
+     * The GcpManagedChannel will add its own label "pool_index" with values "pool-0", "pool-1",
+     * etc. for each instance of GcpManagedChannel created.
+     *
+     * <p>Example usage (e. g. with export to Cloud Monitoring)
+     * <pre>
+     * // Enable Cloud Monitoring exporter.
+     * StackdriverStatsExporter.createAndRegister();
+     *
+     * // Configure metrics options.
+     * GcpMetricsOptions metricsOptions = GcpMetricsOptions.newBuilder(Metrics.getMetricRegistry())
+     *     .withNamePrefix("myapp/gcp-pool/")
+     *     .build());
+     *
+     * final GcpManagedChannel pool =
+     *     (GcpManagedChannel)
+     *         GcpManagedChannelBuilder.forDelegateBuilder(builder)
+     *             .withOptions(
+     *                 GcpManagedChannelOptions.newBuilder()
+     *                     .withMetricsOptions(metricsOptions)
+     *                     .build())
+     *             .build();
+     *
+     * // Use the pool that will emit metrics which will be exported to Cloud Monitoring.
+     * </pre>
+     *
      * @param metricsOptions a {@link GcpMetricsOptions} to use as metrics configuration.
      */
     public Builder withMetricsOptions(GcpMetricsOptions metricsOptions) {

--- a/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannelOptions.java
+++ b/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannelOptions.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.grpc.gcp;
+
+import io.opencensus.metrics.LabelKey;
+import io.opencensus.metrics.LabelValue;
+import io.opencensus.metrics.MetricRegistry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+/** Options for the {@link GcpManagedChannel}. */
+public class GcpManagedChannelOptions {
+  private static final Logger logger = Logger.getLogger(GcpManagedChannelOptions.class.getName());
+
+  private final GcpMetricsOptions metricsOptions;
+
+  public GcpManagedChannelOptions() {
+    metricsOptions = null;
+  }
+
+  public GcpManagedChannelOptions(Builder builder) {
+    metricsOptions = builder.metricsOptions;
+  }
+
+  public GcpMetricsOptions getMetricsOptions() {
+    return metricsOptions;
+  }
+
+  /** Creates a new GcpManagedChannelOptions.Builder. */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private GcpMetricsOptions metricsOptions;
+
+    public Builder() {}
+
+    public GcpManagedChannelOptions build() {
+      return new GcpManagedChannelOptions(this);
+    }
+
+    /**
+     * Sets the metrics configuration for the {@link GcpManagedChannel}.
+     *
+     * @param metricsOptions a {@link GcpMetricsOptions} to use as metrics configuration.
+     */
+    public Builder withMetricsOptions(GcpMetricsOptions metricsOptions) {
+      this.metricsOptions = metricsOptions;
+      return this;
+    }
+  }
+
+  /** Metrics configuration for the GCP managed channel. */
+  public static class GcpMetricsOptions {
+    // Unit to represent count.
+    static final String COUNT = "1";
+
+    private final MetricRegistry metricRegistry;
+    private final List<LabelKey> labelKeys;
+    private final List<LabelValue> labelValues;
+    private final String namePrefix;
+
+    public GcpMetricsOptions(Builder builder) {
+      metricRegistry = builder.metricRegistry;
+      labelKeys = builder.labelKeys;
+      labelValues = builder.labelValues;
+      namePrefix = builder.namePrefix;
+    }
+
+    public MetricRegistry getMetricRegistry() {
+      return metricRegistry;
+    }
+
+    public List<LabelKey> getLabelKeys() {
+      return labelKeys;
+    }
+
+    public List<LabelValue> getLabelValues() {
+      return labelValues;
+    }
+
+    public String getNamePrefix() {
+      return namePrefix;
+    }
+
+    /**
+     * Creates a new GcpMetricsOptions.Builder.
+     *
+     * @param metricRegistry {@link MetricRegistry} to create and register metrics.
+     */
+    public static Builder newBuilder(MetricRegistry metricRegistry) {
+      return new Builder(metricRegistry);
+    }
+
+    public static class Builder {
+      private final MetricRegistry metricRegistry;
+      private List<LabelKey> labelKeys;
+      private List<LabelValue> labelValues;
+      private String namePrefix;
+
+      /**
+       * Constructor for GcpMetricsOptions.Builder.
+       *
+       * @param metricRegistry {@link MetricRegistry} to create and register metrics.
+       */
+      public Builder(MetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
+        labelKeys = new ArrayList<>();
+        labelValues = new ArrayList<>();
+        namePrefix = "";
+      }
+
+      public GcpMetricsOptions build() {
+        return new GcpMetricsOptions(this);
+      }
+
+      /**
+       * Sets label keys and values to report with the metrics. The size of keys and values lists
+       * must match. Otherwise the labels will not be applied.
+       *
+       * @param labelKeys a list of {@link LabelKey}.
+       * @param labelValues a list of {@link LabelValue}.
+       */
+      public Builder withLabels(List<LabelKey> labelKeys, List<LabelValue> labelValues) {
+        if (labelKeys == null || labelValues == null || labelKeys.size() != labelValues.size()) {
+          logger.warning("Unable to set label keys and values - size mismatch or null.");
+          return this;
+        }
+        this.labelKeys = labelKeys;
+        this.labelValues = labelValues;
+        return this;
+      }
+
+      /**
+       * Sets the prefix for all metric names reported by GcpManagedChannel.
+       *
+       * @param namePrefix the prefix for metrics names.
+       */
+      public Builder withNamePrefix(String namePrefix) {
+        this.namePrefix = namePrefix;
+        return this;
+      }
+    }
+  }
+}

--- a/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpMetricsConstants.java
+++ b/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpMetricsConstants.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.grpc.gcp;
+
+public class GcpMetricsConstants {
+  public static String POOL_INDEX_LABEL = "pool_index";
+  public static String POOL_INDEX_DESC = "gRPC GCP channel pool index.";
+
+  public static String METRIC_NUM_CHANNELS = "num_channels";
+  public static String METRIC_MAX_ALLOWED_CHANNELS = "max_allowed_channels";
+  public static String METRIC_MIN_ACTIVE_STREAMS = "min_active_streams";
+  public static String METRIC_MAX_ACTIVE_STREAMS = "max_active_streams";
+  public static String METRIC_NUM_TOTAL_ACTIVE_STREAMS = "num_total_active_streams";
+}

--- a/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpMetricsConstants.java
+++ b/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpMetricsConstants.java
@@ -16,7 +16,7 @@
 
 package com.google.grpc.gcp;
 
-public class GcpMetricsConstants {
+class GcpMetricsConstants {
   public static String POOL_INDEX_LABEL = "pool_index";
   public static String POOL_INDEX_DESC = "gRPC GCP channel pool index.";
 

--- a/grpc-gcp/src/test/java/com/google/grpc/gcp/BigtableIntegrationTest.java
+++ b/grpc-gcp/src/test/java/com/google/grpc/gcp/BigtableIntegrationTest.java
@@ -220,7 +220,8 @@ public class BigtableIntegrationTest {
           new AsyncResponseObserver<MutateRowResponse>();
       stub.mutateRow(request, responseObserver);
       // Test the number of channels.
-      assertEquals(Math.min(i / NEW_MAX_STREAM + 1, NEW_MAX_CHANNEL), gcpChannel.channelRefs.size());
+      assertEquals(
+          Math.min(i / NEW_MAX_STREAM + 1, NEW_MAX_CHANNEL), gcpChannel.channelRefs.size());
       clearObservers.add(responseObserver);
     }
 

--- a/grpc-gcp/src/test/java/com/google/grpc/gcp/MetricRegistryTestUtils.java
+++ b/grpc-gcp/src/test/java/com/google/grpc/gcp/MetricRegistryTestUtils.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.grpc.gcp;
+
+import com.google.common.collect.Maps;
+import io.opencensus.common.ToLongFunction;
+import io.opencensus.metrics.DerivedDoubleCumulative;
+import io.opencensus.metrics.DerivedDoubleGauge;
+import io.opencensus.metrics.DerivedLongCumulative;
+import io.opencensus.metrics.DerivedLongGauge;
+import io.opencensus.metrics.DoubleCumulative;
+import io.opencensus.metrics.DoubleGauge;
+import io.opencensus.metrics.LabelKey;
+import io.opencensus.metrics.LabelValue;
+import io.opencensus.metrics.LongCumulative;
+import io.opencensus.metrics.LongGauge;
+import io.opencensus.metrics.MetricOptions;
+import io.opencensus.metrics.MetricRegistry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+class MetricRegistryTestUtils {
+
+  static class PointWithFunction<T> {
+    private final T ref;
+    private final ToLongFunction<T> function;
+    private final List<LabelKey> key;
+    private final List<LabelValue> values;
+
+    PointWithFunction(
+        T obj, ToLongFunction<T> function, List<LabelKey> keys, List<LabelValue> values) {
+      this.ref = obj;
+      this.function = function;
+      this.key = keys;
+      this.values = values;
+    }
+
+    long value() {
+      return function.applyAsLong(ref);
+    }
+
+    List<LabelKey> keys() {
+      return key;
+    }
+
+    List<LabelValue> values() {
+      return values;
+    }
+  }
+
+  static class MetricsRecord {
+    private final Map<String, List<PointWithFunction>> metrics;
+
+    private MetricsRecord() {
+      this.metrics = Maps.newHashMap();
+    }
+
+    Map<String, List<PointWithFunction>> getMetrics() {
+      return metrics;
+    }
+  }
+
+  public static final class FakeDerivedLongGauge extends DerivedLongGauge {
+    private final MetricsRecord record;
+    private final String name;
+    private final List<LabelKey> labelKeys;
+
+    private FakeDerivedLongGauge(
+        FakeMetricRegistry metricRegistry, String name, List<LabelKey> labelKeys) {
+      this.record = metricRegistry.record;
+      this.labelKeys = labelKeys;
+      this.name = name;
+    }
+
+    @Override
+    public <T> void createTimeSeries(
+        List<LabelValue> labelValues, T t, ToLongFunction<T> toLongFunction) {
+      if (!this.record.metrics.containsKey(this.name)) {
+        this.record.metrics.put(this.name, new ArrayList<>());
+      }
+      this.record
+          .metrics
+          .get(this.name)
+          .add(new PointWithFunction<>(t, toLongFunction, labelKeys, labelValues));
+    }
+
+    @Override
+    public void removeTimeSeries(List<LabelValue> list) {}
+
+    @Override
+    public void clear() {}
+  }
+
+  public static final class FakeDerivedLongCumulative extends DerivedLongCumulative {
+    private final MetricsRecord record;
+    private final String name;
+    private final List<LabelKey> labelKeys;
+
+    private FakeDerivedLongCumulative(
+        FakeMetricRegistry metricRegistry, String name, List<LabelKey> labelKeys) {
+      this.record = metricRegistry.record;
+      this.labelKeys = labelKeys;
+      this.name = name;
+    }
+
+    @Override
+    public <T> void createTimeSeries(
+        List<LabelValue> labelValues, T t, ToLongFunction<T> toLongFunction) {
+      if (!this.record.metrics.containsKey(this.name)) {
+        this.record.metrics.put(this.name, new ArrayList<>());
+      }
+      this.record
+          .metrics
+          .get(this.name)
+          .add(new PointWithFunction<>(t, toLongFunction, labelKeys, labelValues));
+    }
+
+    @Override
+    public void removeTimeSeries(List<LabelValue> list) {}
+
+    @Override
+    public void clear() {}
+  }
+
+  /**
+   * A {@link MetricRegistry} implementation that saves metrics records to be accessible from {@link
+   * #pollRecord()}.
+   */
+  public static final class FakeMetricRegistry extends MetricRegistry {
+
+    private final MetricsRecord record;
+
+    FakeMetricRegistry() {
+      record = new MetricsRecord();
+    }
+
+    MetricsRecord pollRecord() {
+      return record;
+    }
+
+    @Override
+    public DerivedLongGauge addDerivedLongGauge(String s, MetricOptions metricOptions) {
+      return new FakeDerivedLongGauge(this, s, metricOptions.getLabelKeys());
+    }
+
+    @Override
+    public LongGauge addLongGauge(String s, MetricOptions metricOptions) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DoubleGauge addDoubleGauge(String s, MetricOptions metricOptions) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DerivedDoubleGauge addDerivedDoubleGauge(String s, MetricOptions metricOptions) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public LongCumulative addLongCumulative(String s, MetricOptions metricOptions) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DoubleCumulative addDoubleCumulative(String s, MetricOptions metricOptions) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DerivedLongCumulative addDerivedLongCumulative(String s, MetricOptions metricOptions) {
+      return new FakeDerivedLongCumulative(this, s, metricOptions.getLabelKeys());
+    }
+
+    @Override
+    public DerivedDoubleCumulative addDerivedDoubleCumulative(
+        String s, MetricOptions metricOptions) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}


### PR DESCRIPTION
Added GcpManagedChannelOptions to configure GcpManagedChannel.

If MetricRegistry is provided in the GcpManagedChannelOptions then some useful metrics will be reported by GcpManagedChannel:
- The number of channels in the pool.
- The maximum number of channels allowed in the pool.
- The minimum number of active streams on any channel.
- The maximum number of active streams on any channel.
- The total number of active streams across all channels.

The client can provide prefix for the metrics names and labels for the metrics.