### PR TITLE
Enable unresponsive connection detection

### DIFF
--- a/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannel.java
+++ b/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannel.java
@@ -39,6 +39,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
+import io.grpc.Status.Code;
 import io.opencensus.common.ToLongFunction;
 import io.opencensus.metrics.DerivedLongGauge;
 import io.opencensus.metrics.LabelKey;
@@ -701,7 +702,7 @@ public class GcpManagedChannel extends ManagedChannel {
 
     private void detectUnresponsiveConnection(
         long startNanos, Status status, boolean fromClientSide) {
-      if (status == Status.DEADLINE_EXCEEDED) {
+      if (status.getCode().equals(Code.DEADLINE_EXCEEDED)) {
         if (startNanos < lastResponseNanos) {
           // Skip deadline exceeded from past calls.
           return;


### PR DESCRIPTION
Added new resiliency option:
withUnresponsiveConnectionDetection(int ms, int numDroppedRequests)

If an RPC channel fails to receive any RPC message from the server for `ms` milliseconds and there were `numDroppedRequests` calls (started after the last response from the server) that resulted in DEADLINE_EXCEEDED then a graceful reconnection of the channel will be performed.

During the reconnection a new subchannel (connection) will be created for new RPCs, and the calls on the old subchannel will still have a chance to complete if the server side responds. When all RPCs on the old subchannel finish the old connection will be closed.

The `ms` should not be less than the timeout used for the majority of calls. And `numDroppedRequests` must be > 0.

The logic treats any message from the server almost as a "ping" response. But only calls started after the last response received and ended up in DEADLINE_EXCEEDED count towards `numDroppedRequests`. Because of that, it may not detect an unresponsive connection if you have long-running streaming calls only.