### PR TITLE
Change options builders to allow rebuilding

### DIFF
--- a/grpc-gcp/build.gradle
+++ b/grpc-gcp/build.gradle
@@ -13,7 +13,7 @@ repositories {
     mavenLocal()
 }
 
-version = '0.0.1-METRICS'
+version = '0.0.1-SNAPSHOT'
 group = 'com.google.cloud'
 description = 'GRPC-GCP-Extension Java'
 sourceCompatibility = '1.8'

--- a/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannelOptions.java
+++ b/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannelOptions.java
@@ -57,11 +57,21 @@ public class GcpManagedChannelOptions {
     return new Builder();
   }
 
+  /** Creates a new GcpManagedChannelOptions.Builder from GcpManagedChannelOptions. */
+  public static Builder newBuilder(GcpManagedChannelOptions options) {
+    return new Builder(options);
+  }
+
   public static class Builder {
     private GcpMetricsOptions metricsOptions;
     private GcpResiliencyOptions resiliencyOptions;
 
     public Builder() {}
+
+    public Builder(GcpManagedChannelOptions options) {
+      this.metricsOptions = options.getMetricsOptions();
+      this.resiliencyOptions = options.getResiliencyOptions();
+    }
 
     public GcpManagedChannelOptions build() {
       return new GcpManagedChannelOptions(this);
@@ -150,35 +160,47 @@ public class GcpManagedChannelOptions {
       return namePrefix;
     }
 
-    /**
-     * Creates a new GcpMetricsOptions.Builder.
-     *
-     * @param metricRegistry {@link MetricRegistry} to create and register metrics.
-     */
-    public static Builder newBuilder(MetricRegistry metricRegistry) {
-      return new Builder(metricRegistry);
+    /** Creates a new GcpMetricsOptions.Builder. */
+    public static Builder newBuilder() {
+      return new Builder();
+    }
+
+    /** Creates a new GcpMetricsOptions.Builder from GcpMetricsOptions. */
+    public static Builder newBuilder(GcpMetricsOptions options) {
+      return new Builder(options);
     }
 
     public static class Builder {
-      private final MetricRegistry metricRegistry;
+      private MetricRegistry metricRegistry;
       private List<LabelKey> labelKeys;
       private List<LabelValue> labelValues;
       private String namePrefix;
 
-      /**
-       * Constructor for GcpMetricsOptions.Builder.
-       *
-       * @param metricRegistry {@link MetricRegistry} to create and register metrics.
-       */
-      public Builder(MetricRegistry metricRegistry) {
-        this.metricRegistry = metricRegistry;
+      /** Constructor for GcpMetricsOptions.Builder. */
+      public Builder() {
         labelKeys = new ArrayList<>();
         labelValues = new ArrayList<>();
         namePrefix = "";
       }
 
+      public Builder(GcpMetricsOptions options) {
+        this();
+        if (options == null) {
+          return;
+        }
+        this.metricRegistry = options.getMetricRegistry();
+        this.labelKeys = options.getLabelKeys();
+        this.labelValues = options.getLabelValues();
+        this.namePrefix = options.getNamePrefix();
+      }
+
       public GcpMetricsOptions build() {
         return new GcpMetricsOptions(this);
+      }
+
+      public Builder withMetricRegistry(MetricRegistry registry) {
+        this.metricRegistry = registry;
+        return this;
       }
 
       /**
@@ -229,6 +251,11 @@ public class GcpManagedChannelOptions {
       return new Builder();
     }
 
+    /** Creates a new GcpResiliencyOptions.Builder from GcpResiliencyOptions. */
+    public static Builder newBuilder(GcpResiliencyOptions options) {
+      return new Builder(options);
+    }
+
     public boolean isNotReadyFallbackEnabled() {
       return notReadyFallbackEnabled;
     }
@@ -253,17 +280,24 @@ public class GcpManagedChannelOptions {
 
       public Builder() {}
 
+      public Builder(GcpResiliencyOptions options) {
+        this.notReadyFallbackEnabled = options.isNotReadyFallbackEnabled();
+        this.unresponsiveDetectionEnabled = options.isUnresponsiveDetectionEnabled();
+        this.unresponsiveDetectionMs = options.getUnresponsiveDetectionMs();
+        this.unresponsiveDetectionDroppedCount = options.getUnresponsiveDetectionDroppedCount();
+      }
+
       public GcpResiliencyOptions build() {
         return new GcpResiliencyOptions(this);
       }
 
       /**
-       * Temporarily fallback requests to a ready channel from a channel which is not ready to send
-       * a request immediately. The fallback will happen if the pool has another channel in the
-       * READY state and that channel has less than maximum allowed concurrent active streams.
+       * If true, temporarily fallback requests to a ready channel from a channel which is not ready
+       * to send a request immediately. The fallback will happen if the pool has another channel in
+       * the READY state and that channel has less than maximum allowed concurrent active streams.
        */
-      public Builder enableNotReadyFallback() {
-        notReadyFallbackEnabled = true;
+      public Builder setNotReadyFallback(boolean enabled) {
+        notReadyFallbackEnabled = enabled;
         return this;
       }
 
@@ -294,6 +328,12 @@ public class GcpManagedChannelOptions {
         unresponsiveDetectionEnabled = true;
         unresponsiveDetectionMs = ms;
         unresponsiveDetectionDroppedCount = numDroppedRequests;
+        return this;
+      }
+
+      /** Disable unresponsive connection detection. */
+      public Builder disableUnresponsiveConnectionDetection() {
+        unresponsiveDetectionEnabled = false;
         return this;
       }
     }

--- a/grpc-gcp/src/test/java/com/google/grpc/gcp/GcpManagedChannelOptionsTest.java
+++ b/grpc-gcp/src/test/java/com/google/grpc/gcp/GcpManagedChannelOptionsTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.grpc.gcp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.grpc.gcp.GcpManagedChannelOptions.GcpMetricsOptions;
+import com.google.grpc.gcp.GcpManagedChannelOptions.GcpResiliencyOptions;
+import io.opencensus.metrics.LabelKey;
+import io.opencensus.metrics.LabelValue;
+import io.opencensus.metrics.MetricRegistry;
+import io.opencensus.metrics.Metrics;
+import java.util.Collections;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for GcpManagedChannel. */
+@RunWith(JUnit4.class)
+public final class GcpManagedChannelOptionsTest {
+  private static final String namePrefix = "name-prefix";
+  private static final String labelName = "label_name";
+  private static final String labelDescription = "Label description";
+  private static final String labelValue = "label-value";
+  private static final MetricRegistry metricRegistry = Metrics.getMetricRegistry();
+  private static final int unresponsiveMs = 100;
+  private static final int unresponsiveDroppedCount = 3;
+
+  @Rule public ExpectedException exceptionRule = ExpectedException.none();
+
+  private GcpManagedChannelOptions buildOptions() {
+    return GcpManagedChannelOptions.newBuilder()
+        .withMetricsOptions(
+            GcpMetricsOptions.newBuilder()
+                .withNamePrefix(namePrefix)
+                .withLabels(
+                    Collections.singletonList(LabelKey.create(labelName, labelDescription)),
+                    Collections.singletonList(LabelValue.create(labelValue)))
+                .withMetricRegistry(metricRegistry)
+                .build())
+        .withResiliencyOptions(
+            GcpResiliencyOptions.newBuilder()
+                .setNotReadyFallback(true)
+                .withUnresponsiveConnectionDetection(unresponsiveMs, unresponsiveDroppedCount)
+                .build())
+        .build();
+  }
+
+  @Test
+  public void testOptionsBuilders() {
+    final GcpManagedChannelOptions opts = buildOptions();
+
+    assertNotNull(opts.getMetricsOptions());
+    assertNotNull(opts.getResiliencyOptions());
+    GcpMetricsOptions metricsOpts = opts.getMetricsOptions();
+    GcpResiliencyOptions resOpts = opts.getResiliencyOptions();
+    assertEquals(metricRegistry, metricsOpts.getMetricRegistry());
+    assertEquals(namePrefix, metricsOpts.getNamePrefix());
+    assertEquals(1, metricsOpts.getLabelKeys().size());
+    assertEquals(1, metricsOpts.getLabelValues().size());
+    assertEquals(labelName, metricsOpts.getLabelKeys().get(0).getKey());
+    assertEquals(labelDescription, metricsOpts.getLabelKeys().get(0).getDescription());
+    assertEquals(labelValue, metricsOpts.getLabelValues().get(0).getValue());
+    assertTrue(resOpts.isNotReadyFallbackEnabled());
+    assertTrue(resOpts.isUnresponsiveDetectionEnabled());
+    assertEquals(unresponsiveMs, resOpts.getUnresponsiveDetectionMs());
+    assertEquals(unresponsiveDroppedCount, resOpts.getUnresponsiveDetectionDroppedCount());
+  }
+
+  @Test
+  public void testUnresponsiveDetectionMsPreconditions() {
+    exceptionRule.expect(IllegalArgumentException.class);
+    exceptionRule.expectMessage("ms should be > 0, got 0");
+
+    GcpManagedChannelOptions opts =
+        GcpManagedChannelOptions.newBuilder()
+            .withResiliencyOptions(
+                GcpResiliencyOptions.newBuilder().withUnresponsiveConnectionDetection(0, 0).build())
+            .build();
+  }
+
+  @Test
+  public void testUnresponsiveDetectionDroppedCountPreconditions() {
+    exceptionRule.expect(IllegalArgumentException.class);
+    exceptionRule.expectMessage("numDroppedRequests should be > 0, got -1");
+
+    GcpManagedChannelOptions opts =
+        GcpManagedChannelOptions.newBuilder()
+            .withResiliencyOptions(
+                GcpResiliencyOptions.newBuilder()
+                    .withUnresponsiveConnectionDetection(100, -1)
+                    .build())
+            .build();
+  }
+
+  @Test
+  public void testOptionsReBuild() {
+    final GcpManagedChannelOptions opts = buildOptions();
+
+    final String updatedLabelValue = "updated-label-value";
+
+    GcpManagedChannelOptions updatedOptions =
+        GcpManagedChannelOptions.newBuilder(opts)
+            .withMetricsOptions(
+                GcpMetricsOptions.newBuilder(opts.getMetricsOptions())
+                    .withLabels(
+                        Collections.singletonList(LabelKey.create(labelName, labelDescription)),
+                        Collections.singletonList(LabelValue.create(updatedLabelValue)))
+                    .build())
+            .build();
+
+    assertNotNull(updatedOptions.getMetricsOptions());
+    assertNotNull(updatedOptions.getResiliencyOptions());
+    GcpMetricsOptions metricsOpts = updatedOptions.getMetricsOptions();
+    GcpResiliencyOptions resOpts = updatedOptions.getResiliencyOptions();
+    assertEquals(metricRegistry, metricsOpts.getMetricRegistry());
+    assertEquals(namePrefix, metricsOpts.getNamePrefix());
+    assertEquals(1, metricsOpts.getLabelKeys().size());
+    assertEquals(1, metricsOpts.getLabelValues().size());
+    assertEquals(labelName, metricsOpts.getLabelKeys().get(0).getKey());
+    assertEquals(labelDescription, metricsOpts.getLabelKeys().get(0).getDescription());
+    assertEquals(updatedLabelValue, metricsOpts.getLabelValues().get(0).getValue());
+    assertTrue(resOpts.isNotReadyFallbackEnabled());
+    assertTrue(resOpts.isUnresponsiveDetectionEnabled());
+    assertEquals(unresponsiveMs, resOpts.getUnresponsiveDetectionMs());
+    assertEquals(unresponsiveDroppedCount, resOpts.getUnresponsiveDetectionDroppedCount());
+
+    updatedOptions =
+        GcpManagedChannelOptions.newBuilder(opts)
+            .withResiliencyOptions(
+                GcpResiliencyOptions.newBuilder(opts.getResiliencyOptions())
+                    .setNotReadyFallback(false)
+                    .build())
+            .build();
+
+    assertNotNull(updatedOptions.getMetricsOptions());
+    assertNotNull(updatedOptions.getResiliencyOptions());
+    metricsOpts = updatedOptions.getMetricsOptions();
+    resOpts = updatedOptions.getResiliencyOptions();
+    assertEquals(metricRegistry, metricsOpts.getMetricRegistry());
+    assertEquals(namePrefix, metricsOpts.getNamePrefix());
+    assertEquals(1, metricsOpts.getLabelKeys().size());
+    assertEquals(1, metricsOpts.getLabelValues().size());
+    assertEquals(labelName, metricsOpts.getLabelKeys().get(0).getKey());
+    assertEquals(labelDescription, metricsOpts.getLabelKeys().get(0).getDescription());
+    assertEquals(labelValue, metricsOpts.getLabelValues().get(0).getValue());
+    assertFalse(resOpts.isNotReadyFallbackEnabled());
+    assertTrue(resOpts.isUnresponsiveDetectionEnabled());
+    assertEquals(unresponsiveMs, resOpts.getUnresponsiveDetectionMs());
+    assertEquals(unresponsiveDroppedCount, resOpts.getUnresponsiveDetectionDroppedCount());
+  }
+}

--- a/grpc-gcp/src/test/java/com/google/grpc/gcp/GcpManagedChannelTest.java
+++ b/grpc-gcp/src/test/java/com/google/grpc/gcp/GcpManagedChannelTest.java
@@ -312,7 +312,8 @@ public final class GcpManagedChannelTest {
                 .withOptions(
                     GcpManagedChannelOptions.newBuilder()
                         .withMetricsOptions(
-                            GcpMetricsOptions.newBuilder(fakeRegistry)
+                            GcpMetricsOptions.newBuilder()
+                                .withMetricRegistry(fakeRegistry)
                                 .withNamePrefix(prefix)
                                 .withLabels(labelKeys, labelValues)
                                 .build())


### PR DESCRIPTION
Changed options builders to allow creating new options based on provided options.
Added possibility to disable `notReadyFallback` and `unresponsiveConnectionDetection`.