### PR TITLE
More metrics

### DIFF
--- a/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannel.java
+++ b/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannel.java
@@ -223,7 +223,7 @@ public class GcpManagedChannel extends ManagedChannel {
     labelKeys.add(poolKey);
     labelKeysWithResult.add(poolKey);
     final LabelValue poolIndex =
-        LabelValue.create(String.format("pool-%d", channelPoolIndex.getAndIncrement()));
+        LabelValue.create(String.format("pool-%d", channelPoolIndex.incrementAndGet()));
     labelValues.add(poolIndex);
     labelValuesSuccess.add(poolIndex);
     labelValuesError.add(poolIndex);

--- a/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannelOptions.java
+++ b/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannelOptions.java
@@ -129,9 +129,6 @@ public class GcpManagedChannelOptions {
 
   /** Metrics configuration for the GCP managed channel. */
   public static class GcpMetricsOptions {
-    // Unit to represent count.
-    static final String COUNT = "1";
-
     private final MetricRegistry metricRegistry;
     private final List<LabelKey> labelKeys;
     private final List<LabelValue> labelValues;

--- a/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpMetricsConstants.java
+++ b/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpMetricsConstants.java
@@ -19,8 +19,8 @@ package com.google.grpc.gcp;
 class GcpMetricsConstants {
   public static String POOL_INDEX_LABEL = "pool_index";
   public static String POOL_INDEX_DESC = "gRPC GCP channel pool index.";
-  public static String RESULT_LABEL = "rpc_result";
-  public static String RESULT_DESC = "RPC call result.";
+  public static String RESULT_LABEL = "result";
+  public static String RESULT_DESC = "Outcome.";
   public static String RESULT_SUCCESS = "SUCCESS";
   public static String RESULT_ERROR = "ERROR";
 
@@ -47,4 +47,5 @@ class GcpMetricsConstants {
   public static String METRIC_MIN_CALLS = "min_calls_per_channel";
   public static String METRIC_MAX_CALLS = "max_calls_per_channel";
   public static String METRIC_NUM_CALLS_COMPLETED = "num_calls_completed";
+  public static String METRIC_NUM_FALLBACKS = "num_fallbacks";
 }

--- a/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpMetricsConstants.java
+++ b/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpMetricsConstants.java
@@ -19,10 +19,32 @@ package com.google.grpc.gcp;
 class GcpMetricsConstants {
   public static String POOL_INDEX_LABEL = "pool_index";
   public static String POOL_INDEX_DESC = "gRPC GCP channel pool index.";
+  public static String RESULT_LABEL = "rpc_result";
+  public static String RESULT_DESC = "RPC call result.";
+  public static String RESULT_SUCCESS = "SUCCESS";
+  public static String RESULT_ERROR = "ERROR";
 
-  public static String METRIC_NUM_CHANNELS = "num_channels";
+  // Unit to represent count.
+  static final String COUNT = "1";
+  static final String MICROSECOND = "us";
+
+  public static String METRIC_MAX_CHANNELS = "max_channels";
+  public static String METRIC_MIN_READY_CHANNELS = "min_ready_channels";
+  public static String METRIC_MAX_READY_CHANNELS = "max_ready_channels";
   public static String METRIC_MAX_ALLOWED_CHANNELS = "max_allowed_channels";
-  public static String METRIC_MIN_ACTIVE_STREAMS = "min_active_streams";
-  public static String METRIC_MAX_ACTIVE_STREAMS = "max_active_streams";
-  public static String METRIC_NUM_TOTAL_ACTIVE_STREAMS = "num_total_active_streams";
+  public static String METRIC_NUM_CHANNEL_DISCONNECT = "num_channel_disconnect";
+  public static String METRIC_NUM_CHANNEL_CONNECT = "num_channel_connect";
+  public static String METRIC_MIN_CHANNEL_READINESS_TIME = "min_channel_readiness_time";
+  public static String METRIC_AVG_CHANNEL_READINESS_TIME = "avg_channel_readiness_time";
+  public static String METRIC_MAX_CHANNEL_READINESS_TIME = "max_channel_readiness_time";
+  public static String METRIC_MIN_ACTIVE_STREAMS = "min_active_streams_per_channel";
+  public static String METRIC_MAX_ACTIVE_STREAMS = "max_active_streams_per_channel";
+  public static String METRIC_MIN_TOTAL_ACTIVE_STREAMS = "min_total_active_streams";
+  public static String METRIC_MAX_TOTAL_ACTIVE_STREAMS = "max_total_active_streams";
+  public static String METRIC_MIN_AFFINITY = "min_affinity_per_channel";
+  public static String METRIC_MAX_AFFINITY = "max_affinity_per_channel";
+  public static String METRIC_NUM_AFFINITY = "num_affinity";
+  public static String METRIC_MIN_CALLS = "min_calls_per_channel";
+  public static String METRIC_MAX_CALLS = "max_calls_per_channel";
+  public static String METRIC_NUM_CALLS_COMPLETED = "num_calls_completed";
 }

--- a/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpMetricsConstants.java
+++ b/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpMetricsConstants.java
@@ -27,6 +27,7 @@ class GcpMetricsConstants {
   // Unit to represent count.
   static final String COUNT = "1";
   static final String MICROSECOND = "us";
+  static final String MILLISECOND = "ms";
 
   public static String METRIC_MAX_CHANNELS = "max_channels";
   public static String METRIC_MIN_READY_CHANNELS = "min_ready_channels";
@@ -48,4 +49,9 @@ class GcpMetricsConstants {
   public static String METRIC_MAX_CALLS = "max_calls_per_channel";
   public static String METRIC_NUM_CALLS_COMPLETED = "num_calls_completed";
   public static String METRIC_NUM_FALLBACKS = "num_fallbacks";
+  public static String METRIC_NUM_UNRESPONSIVE_DETECTIONS = "num_unresponsive_detections";
+  public static String METRIC_MIN_UNRESPONSIVE_DETECTION_TIME = "min_unresponsive_detection_time";
+  public static String METRIC_MAX_UNRESPONSIVE_DETECTION_TIME = "max_unresponsive_detection_time";
+  public static String METRIC_MIN_UNRESPONSIVE_DROPPED_CALLS = "min_unresponsive_dropped_calls";
+  public static String METRIC_MAX_UNRESPONSIVE_DROPPED_CALLS = "max_unresponsive_dropped_calls";
 }

--- a/grpc-gcp/src/test/java/com/google/grpc/gcp/GcpManagedChannelTest.java
+++ b/grpc-gcp/src/test/java/com/google/grpc/gcp/GcpManagedChannelTest.java
@@ -346,7 +346,7 @@ public final class GcpManagedChannelTest {
       }
 
       MetricsRecord record = fakeRegistry.pollRecord();
-      assertThat(record.getMetrics().size()).isEqualTo(19);
+      assertThat(record.getMetrics().size()).isEqualTo(20);
 
       List<PointWithFunction> numChannels =
           record.getMetrics().get(prefix + GcpMetricsConstants.METRIC_MAX_CHANNELS);

--- a/grpc-gcp/src/test/java/com/google/grpc/gcp/GcpManagedChannelTest.java
+++ b/grpc-gcp/src/test/java/com/google/grpc/gcp/GcpManagedChannelTest.java
@@ -333,7 +333,7 @@ public final class GcpManagedChannelTest {
         LabelKey.create(GcpMetricsConstants.POOL_INDEX_LABEL, GcpMetricsConstants.POOL_INDEX_DESC));
     List<LabelValue> expectedLabelValues = new ArrayList<>();
     expectedLabelValues.addAll(labelValues);
-    expectedLabelValues.add(LabelValue.create("pool-0"));
+    expectedLabelValues.add(LabelValue.create("pool-1"));
 
     try {
       // Let's fill five channels with some fake streams.


### PR DESCRIPTION
- Added more metrics for better visibility on channels readiness, channels reconnections, affinity counts, active streams, and completed RPC calls.
- Changed pool_index to be 1-based to match Spanner labels.
- Added a metric to monitor successful and failed fallbacks.
- Added metrics to monitor unresponsive connection detection count, latency, number of dropped calls.