### PR TITLE
Prepare for maxConcurrentStreamsLowWatermark to be 0.

### DIFF
--- a/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannel.java
+++ b/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannel.java
@@ -885,7 +885,13 @@ public class GcpManagedChannel extends ManagedChannel {
 
   @Override
   public synchronized String authority() {
-    return channelRefs.get(0).getChannel().authority();
+    if (channelRefs.size() > 0) {
+      return channelRefs.get(0).getChannel().authority();
+    }
+    final ManagedChannel channel = delegateChannelBuilder.build();
+    final String authority = channel.authority();
+    channel.shutdownNow();
+    return authority;
   }
 
   /**

--- a/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannel.java
+++ b/grpc-gcp/src/main/java/com/google/grpc/gcp/GcpManagedChannel.java
@@ -192,8 +192,6 @@ public class GcpManagedChannel extends ManagedChannel {
       this.maxSize = poolSize;
     }
     this.delegateChannelBuilder = delegateChannelBuilder;
-    // Initialize the first delegate channel.
-    getChannelRef(null);
     this.options = options;
     initOptions();
     if (options.getResiliencyOptions() != null) {
@@ -997,7 +995,8 @@ public class GcpManagedChannel extends ManagedChannel {
     } else if (shutdown > 0) {
       return ConnectivityState.SHUTDOWN;
     }
-    return null;
+    // When no channels are created yet it is also IDLE.
+    return ConnectivityState.IDLE;
   }
 
   /**

--- a/grpc-gcp/src/main/proto/google/grpc/gcp/proto/grpc_gcp.proto
+++ b/grpc-gcp/src/main/proto/google/grpc/gcp/proto/grpc_gcp.proto
@@ -36,6 +36,8 @@ message ChannelPoolConfig {
   // The low watermark of max number of concurrent streams in a channel.
   // New channel will be created once it get hit, until we reach the max size
   // of the channel pool.
+  // Values outside of [0..100] will be ignored. 0 = always create a new channel
+  // until max size is reached.
   uint32 max_concurrent_streams_low_watermark = 3;
 }
 

--- a/grpc-gcp/src/test/java/com/google/grpc/gcp/GcpManagedChannelTest.java
+++ b/grpc-gcp/src/test/java/com/google/grpc/gcp/GcpManagedChannelTest.java
@@ -96,7 +96,7 @@ public final class GcpManagedChannelTest {
             GcpManagedChannelBuilder.forDelegateBuilder(builder)
                 .withApiConfigJsonFile(configFile)
                 .build();
-    assertEquals(1, gcpChannel.channelRefs.size());
+    assertEquals(0, gcpChannel.channelRefs.size());
     assertEquals(3, gcpChannel.getMaxSize());
     assertEquals(2, gcpChannel.getStreamsLowWatermark());
     assertEquals(3, gcpChannel.methodToAffinity.size());
@@ -117,7 +117,7 @@ public final class GcpManagedChannelTest {
             GcpManagedChannelBuilder.forDelegateBuilder(builder)
                 .withApiConfigJsonString(sb.toString())
                 .build();
-    assertEquals(1, gcpChannel.channelRefs.size());
+    assertEquals(0, gcpChannel.channelRefs.size());
     assertEquals(3, gcpChannel.getMaxSize());
     assertEquals(2, gcpChannel.getStreamsLowWatermark());
     assertEquals(3, gcpChannel.methodToAffinity.size());
@@ -125,8 +125,9 @@ public final class GcpManagedChannelTest {
 
   @Test
   public void testGetChannelRefInitialization() throws Exception {
-    // Should have a managedchannel by default.
-    assertEquals(1, gcpChannel.channelRefs.size());
+    // Should not have a managedchannel by default.
+    assertEquals(0, gcpChannel.channelRefs.size());
+    // But once requested it's there.
     assertEquals(0, gcpChannel.getChannelRef(null).getAffinityCount());
     // The state of this channel is idle.
     assertEquals(ConnectivityState.IDLE, gcpChannel.getState(false));
@@ -177,8 +178,8 @@ public final class GcpManagedChannelTest {
     gcpChannel.bind(cf1, Arrays.asList("key1"));
     gcpChannel.bind(cf2, Arrays.asList("key2"));
     gcpChannel.bind(cf1, Arrays.asList("key1"));
-    assertEquals(2, gcpChannel.channelRefs.get(1).getAffinityCount());
-    assertEquals(1, gcpChannel.channelRefs.get(2).getAffinityCount());
+    assertEquals(2, gcpChannel.channelRefs.get(0).getAffinityCount());
+    assertEquals(1, gcpChannel.channelRefs.get(1).getAffinityCount());
     assertEquals(2, gcpChannel.affinityKeyToChannelRef.size());
 
     // Unbind the affinity key.
@@ -187,8 +188,8 @@ public final class GcpManagedChannelTest {
     gcpChannel.unbind(Arrays.asList("key1"));
     gcpChannel.unbind(Arrays.asList("key2"));
     assertEquals(0, gcpChannel.affinityKeyToChannelRef.size());
+    assertEquals(0, gcpChannel.channelRefs.get(0).getAffinityCount());
     assertEquals(0, gcpChannel.channelRefs.get(1).getAffinityCount());
-    assertEquals(0, gcpChannel.channelRefs.get(2).getAffinityCount());
   }
 
   @Test


### PR DESCRIPTION
For some cases we need the first N unbound requests to land one per each channel up to N max channels. E.g. when Spanner fills its session pool on startup using BatchCreateSessions requests.

We can also achieve that with maxConcurrentStreamsLowWatermark set to 1 if those first BatchCreateSessions requests always run in parallel. But because we cannot guarantee that it is safer to use 0 as it will also work even if the requests are run sequentially.