### PR TITLE
Adjust Spanner tests to use zero low watermark.

### DIFF
--- a/grpc-gcp/src/test/resources/spannertest.json
+++ b/grpc-gcp/src/test/resources/spannertest.json
@@ -1,7 +1,7 @@
 {
   "channelPool": {
     "maxSize": 3,
-    "maxConcurrentStreamsLowWatermark": 2
+    "maxConcurrentStreamsLowWatermark": 0
   },
   "method": [
     {


### PR DESCRIPTION
For Spanner we want first N requests (without affinity) to be distributed across N channels. This is to ensure Spanner sessions will be evenly distributed across channels on client startup.