### PR TITLE
Adjust bind/unbind logic and remove bindLock.

### DIFF
--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannel.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannel.java
@@ -977,6 +977,9 @@ public class GcpManagedChannel extends ManagedChannel {
    * channel.
    */
   protected void bind(ChannelRef channelRef, List<String> affinityKeys) {
+    if (channelRef == null || affinityKeys == null) {
+      return;
+    }
     for (String affinityKey : affinityKeys) {
       while (affinityKeyToChannelRef.putIfAbsent(affinityKey, channelRef) != null) {
         unbind(Collections.singletonList(affinityKey));
@@ -987,6 +990,9 @@ public class GcpManagedChannel extends ManagedChannel {
 
   /** Unbind channel with affinity key. */
   protected void unbind(List<String> affinityKeys) {
+    if (affinityKeys == null) {
+      return;
+    }
     for (String affinityKey : affinityKeys) {
       ChannelRef channelRef = affinityKeyToChannelRef.remove(affinityKey);
       if (channelRef != null) {

--- a/grpc-gcp/src/test/java/com/google/cloud/grpc/GcpManagedChannelTest.java
+++ b/grpc-gcp/src/test/java/com/google/cloud/grpc/GcpManagedChannelTest.java
@@ -178,19 +178,35 @@ public final class GcpManagedChannelTest {
     gcpChannel.channelRefs.add(cf2);
     gcpChannel.bind(cf1, Arrays.asList("key1"));
     gcpChannel.bind(cf2, Arrays.asList("key2"));
+    gcpChannel.bind(cf2, Arrays.asList("key3"));
+    // Binding the same key to the same channel should not increase affinity count.
     gcpChannel.bind(cf1, Arrays.asList("key1"));
+    assertEquals(1, gcpChannel.channelRefs.get(0).getAffinityCount());
+    assertEquals(2, gcpChannel.channelRefs.get(1).getAffinityCount());
+    assertEquals(3, gcpChannel.affinityKeyToChannelRef.size());
+    // Binding the same key to a different channel should alter affinity counts accordingly.
+    gcpChannel.bind(cf1, Arrays.asList("key3"));
     assertEquals(2, gcpChannel.channelRefs.get(0).getAffinityCount());
     assertEquals(1, gcpChannel.channelRefs.get(1).getAffinityCount());
-    assertEquals(2, gcpChannel.affinityKeyToChannelRef.size());
+    assertEquals(3, gcpChannel.affinityKeyToChannelRef.size());
 
     // Unbind the affinity key.
     gcpChannel.unbind(Arrays.asList("key1"));
+    assertEquals(1, gcpChannel.channelRefs.get(0).getAffinityCount());
+    assertEquals(1, gcpChannel.channelRefs.get(1).getAffinityCount());
     assertEquals(2, gcpChannel.affinityKeyToChannelRef.size());
     gcpChannel.unbind(Arrays.asList("key1"));
+    assertEquals(1, gcpChannel.channelRefs.get(0).getAffinityCount());
+    assertEquals(1, gcpChannel.channelRefs.get(1).getAffinityCount());
+    assertEquals(2, gcpChannel.affinityKeyToChannelRef.size());
     gcpChannel.unbind(Arrays.asList("key2"));
-    assertEquals(0, gcpChannel.affinityKeyToChannelRef.size());
+    assertEquals(1, gcpChannel.channelRefs.get(0).getAffinityCount());
+    assertEquals(0, gcpChannel.channelRefs.get(1).getAffinityCount());
+    assertEquals(1, gcpChannel.affinityKeyToChannelRef.size());
+    gcpChannel.unbind(Arrays.asList("key3"));
     assertEquals(0, gcpChannel.channelRefs.get(0).getAffinityCount());
     assertEquals(0, gcpChannel.channelRefs.get(1).getAffinityCount());
+    assertEquals(0, gcpChannel.affinityKeyToChannelRef.size());
   }
 
   @Test


### PR DESCRIPTION
1. Remove bindLock to allow parallel binds. For example, keys A, B, C to channel 1, keys D, E, F to channel 2.
2. Unbind a key without waiting for a channel to reach zero affinity count.
3. Allow to rebind a key to another channel and adjust affinity counts accordingly.
4. Binding the same key to the same channel more than once should not increase affinity count by more than 1.