### PR TITLE
ChannelRefs remake

### DIFF
--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannel.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannel.java
@@ -81,8 +81,6 @@ public class GcpManagedChannel extends ManagedChannel {
 
   @VisibleForTesting final List<ChannelRef> channelRefs = new CopyOnWriteArrayList<>();
 
-  private final Map<Integer, ChannelRef> channelRefById = new HashMap<>();
-
   // Metrics configuration.
   private MetricRegistry metricRegistry;
   private final List<LabelKey> labelKeys = new ArrayList<>();
@@ -779,7 +777,7 @@ public class GcpManagedChannel extends ManagedChannel {
     if (channelId != null && !fallbackMap.containsKey(channelId)) {
       // Fallback channel is ready.
       fallbacksSucceeded.incrementAndGet();
-      return channelRefById.get(channelId);
+      return channelRefs.get(channelId);
     }
     // No temp mapping for this key or fallback channel is also broken.
     ChannelRef channelRef = pickLeastBusyChannel();
@@ -793,7 +791,7 @@ public class GcpManagedChannel extends ManagedChannel {
     fallbacksFailed.incrementAndGet();
     if (channelId != null) {
       // Stick with previous mapping if fallback has failed.
-      return channelRefById.get(channelId);
+      return channelRefs.get(channelId);
     }
     return mappedChannel;
   }
@@ -804,7 +802,6 @@ public class GcpManagedChannel extends ManagedChannel {
     final int size = channelRefs.size();
     ChannelRef channelRef = new ChannelRef(delegateChannelBuilder.build(), size);
     channelRefs.add(channelRef);
-    channelRefById.put(size, channelRef);
     return channelRef;
   }
 


### PR DESCRIPTION
1. Changed channelRefs to CopyOnWriteArrayList because we mutate this list only when we add a new channel, i.e., N times during the pool lifetime (N = pool max size). Other times we only traverse the list. This change allowed to remove synchronization from many methods. But most important is the removal of synchronization from pickLeastBusyChannel method and effectively from getChannelRef method which allows for concurrent channel picking for requests without an affinity key too. (Channel picking for requests with an affinity key wasn't synchronized previously).
2. Removed sorting of the channelRef list from pickLeastBusyChannel method because we only need at most two least busy candidates (one in any state and another in the ready state) which we can get with one pass. Thus reducing time complexity of pickLeastBusyChannel from O(n*logn) to O(n).
3. Added tests describing and verifying the fallback logic.
4. As we don't sort the channelRefs list anymore and we guarantee that a channelRef's list index matches channelRef's id, we don't need channelRefById map anymore.