### PR TITLE
Include fs.open in the totla elapsed time

### DIFF
--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GcsioClient.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GcsioClient.java
@@ -123,8 +123,8 @@ public class GcsioClient {
 
     ByteBuffer buff = ByteBuffer.allocate(size);
     for (int i = 0; i < args.calls; i++) {
-      ReadableByteChannel readChannel = gcsfs.open(uri);
       long start = System.currentTimeMillis();
+      ReadableByteChannel readChannel = gcsfs.open(uri);
       readChannel.read(buff);
       long dur = System.currentTimeMillis() - start;
       if (buff.remaining() > 0) {
@@ -153,9 +153,9 @@ public class GcsioClient {
 
     URI uri = URI.create("gs://" + args.bkt + "/" + args.obj + "_" + idx);
     for (int i = 0; i < args.calls; i++) {
+      long start = System.currentTimeMillis();
       WritableByteChannel writeChannel = gcsfs.create(uri);
       ByteBuffer buff = ByteBuffer.wrap(randBytes);
-      long start = System.currentTimeMillis();
       writeChannel.write(buff);
       writeChannel.close();
       // write operation is async, need to call close() to wait for finish.


### PR DESCRIPTION
GCSIO started reading a chunk of data when opening the file (gcsfs.open), making the total elapsed time measured between right after opening and before closing smaller than it should be, At the worse case, it results in 0 with a small file like 100KB. To address this, a stopwatch started before opening the file although it may include additional stuff, which could make this look worse than a plain gRPC.