### PR TITLE
Upgrade guava to 31.0.1-jre

### DIFF
--- a/end2end-test-examples/gcs/build.gradle
+++ b/end2end-test-examples/gcs/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     compile "com.google.cloud:google-cloud-storage:1.113.9"
     compile "com.google.cloud.bigdataoss:gcsio:${gcsioVersion}"
     compile "com.google.cloud.bigdataoss:bigdataoss-parent:${gcsioVersion}"
-    compile "com.google.guava:guava:30.1.1-jre"
+    compile "com.google.guava:guava:31.0.1-jre"
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }


### PR DESCRIPTION
Without this, it will have 31.0.1-android which causes the following exception.

```
Exception in thread "main" java.lang.NoSuchMethodError: com.google.common.cache.CacheBuilder.expireAfterWrite(Ljava/time/Duration;)Lcom/google/common/cache/CacheBuilder;
	at com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl.<init>(GoogleCloudStorageImpl.java:202)
	at com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl.<init>(GoogleCloudStorageImpl.java:317)
	at com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl.<init>(GoogleCloudStorageImpl.java:278)
	at com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem.<init>(GoogleCloudStorageFileSystem.java:150)
	at io.grpc.gcs.GcsioClient.makeWriteRequest(GcsioClient.java:152)
	at io.grpc.gcs.GcsioClient.startCalls(GcsioClient.java:67)
	at io.grpc.gcs.TestMain.main(TestMain.java:47)
```