### PR TITLE
Added host2 for gRPC

### DIFF
--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/Args.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/Args.java
@@ -21,6 +21,7 @@ public class Args {
   final int calls;
   final String cookie;
   final String host;
+  final String host2;
   final int port;
   final String service_path;
   final String access_token;
@@ -52,6 +53,7 @@ public class Args {
     parser.addArgument("--calls").type(Integer.class).setDefault(1);
     parser.addArgument("--cookie").type(String.class).setDefault("");
     parser.addArgument("--host").type(String.class).setDefault(DEFAULT_HOST);
+    parser.addArgument("--host2").type(String.class).setDefault("");
     parser.addArgument("--port").type(Integer.class).setDefault(PORT);
     parser.addArgument("--service_path").type(String.class).setDefault("storage/v1/");
     parser.addArgument("--access_token").type(String.class).setDefault("");
@@ -80,6 +82,7 @@ public class Args {
     calls = ns.getInt("calls");
     cookie = ns.getString("cookie");
     host = ns.getString("host");
+    host2 = ns.getString("host2");
     port = ns.getInt("port");
     service_path = ns.getString("service_path");
     access_token = ns.getString("access_token");

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GcsioClient.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GcsioClient.java
@@ -10,6 +10,7 @@ import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
+import com.google.common.base.Strings;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
@@ -50,6 +51,7 @@ public class GcsioClient {
             .setDirectPathPreffered(args.dp)
             .setReadChannelOptions(
                 GoogleCloudStorageReadOptions.builder()
+                    .setGrpcServerAddress(Strings.isNullOrEmpty(args.host2) ? null : args.host2)
                     .setGrpcChecksumsEnabled(args.checksum)
                     .build())
             .setWriteChannelOptions(


### PR DESCRIPTION
This is a temporary workaround to support different endpoints for json and grpc. Currently staging gcs has two different endpoints for gRPC and HTTP but this will be a single endpoint like how prod does so this will be removed later.