### PR TITLE
Consolidate channel pool config in the GcpChannelPoolOptions.

### DIFF
--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannelBuilder.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannelBuilder.java
@@ -63,7 +63,10 @@ public class GcpManagedChannelBuilder extends ForwardingChannelBuilder<GcpManage
     return new GcpManagedChannelBuilder(delegate);
   }
 
-  /** Sets the channel pool size. This will override the pool size configuration in ApiConfig. */
+  /** Sets the maximum channel pool size. This will override the pool size configuration in ApiConfig.
+   * Deprecated. Use maxSize in GcpManagedChannelOptions.GcpChannelPoolOptions.
+   */
+  @Deprecated
   public GcpManagedChannelBuilder setPoolSize(int poolSize) {
     this.poolSize = poolSize;
     return this;

--- a/grpc-gcp/src/main/proto/google/grpc/gcp/proto/grpc_gcp.proto
+++ b/grpc-gcp/src/main/proto/google/grpc/gcp/proto/grpc_gcp.proto
@@ -21,14 +21,19 @@ option java_outer_classname = "GcpExtensionProto";
 option java_package = "com.google.cloud.grpc.proto";
 
 message ApiConfig {
+  // Deprecated. Use GcpManagedChannelOptions.GcpChannelPoolOptions class.
   // The channel pool configurations.
-  ChannelPoolConfig channel_pool = 2;
+  ChannelPoolConfig channel_pool = 2 [deprecated = true];
 
   // The method configurations.
   repeated MethodConfig method = 1001;
 }
 
+
+// Deprecated. Use GcpManagedChannelOptions.GcpChannelPoolOptions class.
 message ChannelPoolConfig {
+  option deprecated = true;
+
   // The max number of channels in the pool.
   uint32 max_size = 1;
   // The idle timeout (seconds) of channels without bound affinity sessions.


### PR DESCRIPTION
Start moving channel pool related configuration into GcpChannelPoolOptions
inside GcpManagedChannelOptions.

Deprecate previous locations of pool config.

Currently, we have several places to define max pool size, and we have a new
pool related config options to come in the following PRs.

We want to have a single place to define pool-related configuration. We will
keep ApiConfig as a configuration for API methods only and move everything else
into GcpManagedChannelOptions.

/cc @wenbozhu 