### PR TITLE
echo-client: Send metrics

### DIFF
--- a/end2end-test-examples/echo-client/Dockerfile
+++ b/end2end-test-examples/echo-client/Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:11-jre
+
+ADD target/echo-client-2.3-SNAPSHOT.jar /app/
+
+WORKDIR /app
+
+ENTRYPOINT ["java", "-jar", "echo-client-2.3-SNAPSHOT.jar"]

--- a/end2end-test-examples/echo-client/README.md
+++ b/end2end-test-examples/echo-client/README.md
@@ -84,3 +84,29 @@ Per sec Payload = 0.07 MB (exact amount of KB = 10000)
 `--logMaxFiles`: If log file size is limited rotate log files and keep this number of files. Default: unlimited.
  
 `--disableConsoleLog`: If logging to a file do not log to console. Default: false.
+
+## Deployment
+
+Build the jar using maven (`mvn clean package`) or docker:
+
+```shell
+docker run -it --rm -v "$(pwd)":/usr/src/mymaven -w /usr/src/mymaven maven mvn clean package
+```
+
+Deploy the `target/echo-client-2.3-SNAPSHOT.jar` or build a docker image with the jar:
+
+```shell
+docker build -t echo-client:2.3 .
+```
+
+Run the jar:
+
+```shell
+java -jar echo-client-2.3-SNAPSHOT.jar --numRpcs=1 --reqSize=100 --resSize=100 --host=grpc-cloudapi.googleapis.com
+```
+
+Or run a container:
+
+```shell
+docker run -it --rm echo-client:2.3 --numRpcs=1 --reqSize=100 --resSize=100 --host=grpc-cloudapi.googleapis.com
+```

--- a/end2end-test-examples/echo-client/README.md
+++ b/end2end-test-examples/echo-client/README.md
@@ -85,6 +85,12 @@ Per sec Payload = 0.07 MB (exact amount of KB = 10000)
  
 `--disableConsoleLog`: If logging to a file do not log to console. Default: false.
 
+`--metricName`: Ship metrics to Google Cloud Monitoring with this prefix for metric names.
+
+`--metricTaskPrefix`: Prefix for the process label for metrics.
+
+`--metricProbeName`: Additional label for metrics.
+
 ## Deployment
 
 Build the jar using maven (`mvn clean package`) or docker:

--- a/end2end-test-examples/echo-client/build.gradle
+++ b/end2end-test-examples/echo-client/build.gradle
@@ -7,10 +7,11 @@ plugins {
 group 'io.grpc'
 version '2.2-SNAPSHOT'
 
-sourceCompatibility = 1.8
+sourceCompatibility = 1.9
+targetCompatibility = 1.9
 
-def grpcVersion = '1.34.1'
-def protobufVersion = '3.9.0'
+def grpcVersion = '1.45.0'
+def protobufVersion = '3.19.4'
 def protocVersion = protobufVersion
 
 repositories {
@@ -23,7 +24,7 @@ dependencies {
     implementation "io.grpc:grpc-testing:${grpcVersion}"
     implementation "io.grpc:grpc-netty-shaded:${grpcVersion}"
     implementation "io.grpc:grpc-census:${grpcVersion}"
-    implementation "net.sourceforge.argparse4j:argparse4j:0.8.1"
+    implementation "net.sourceforge.argparse4j:argparse4j:0.9.0"
     implementation "com.google.protobuf:protobuf-java-util:${protobufVersion}"
     implementation "org.hdrhistogram:HdrHistogram:2.1.11"
 

--- a/end2end-test-examples/echo-client/build.gradle
+++ b/end2end-test-examples/echo-client/build.gradle
@@ -30,7 +30,6 @@ dependencies {
     implementation "org.hdrhistogram:HdrHistogram:2.1.12"
     implementation "io.opencensus:opencensus-api:${opencensusVersion}"
     implementation "io.opencensus:opencensus-impl:${opencensusVersion}"
-    implementation "io.opencensus:opencensus-exporter-metrics-ocagent:${opencensusVersion}"
     implementation "io.opencensus:opencensus-exporter-stats-stackdriver:${opencensusVersion}"
 
     implementation "org.apache.commons:commons-math3:3.6.1"

--- a/end2end-test-examples/echo-client/build.gradle
+++ b/end2end-test-examples/echo-client/build.gradle
@@ -11,7 +11,7 @@ sourceCompatibility = 1.9
 targetCompatibility = 1.9
 
 def grpcVersion = '1.34.1'
-def protobufVersion = '3.19.4'
+def protobufVersion = '3.9.0'
 def protocVersion = protobufVersion
 def opencensusVersion = '0.31.0'
 

--- a/end2end-test-examples/echo-client/build.gradle
+++ b/end2end-test-examples/echo-client/build.gradle
@@ -13,6 +13,7 @@ targetCompatibility = 1.9
 def grpcVersion = '1.45.0'
 def protobufVersion = '3.19.4'
 def protocVersion = protobufVersion
+def opencensusVersion = '0.31.0'
 
 repositories {
     mavenCentral()
@@ -26,7 +27,11 @@ dependencies {
     implementation "io.grpc:grpc-census:${grpcVersion}"
     implementation "net.sourceforge.argparse4j:argparse4j:0.9.0"
     implementation "com.google.protobuf:protobuf-java-util:${protobufVersion}"
-    implementation "org.hdrhistogram:HdrHistogram:2.1.11"
+    implementation "org.hdrhistogram:HdrHistogram:2.1.12"
+    implementation "io.opencensus:opencensus-api:${opencensusVersion}"
+    implementation "io.opencensus:opencensus-impl:${opencensusVersion}"
+    implementation "io.opencensus:opencensus-exporter-metrics-ocagent:${opencensusVersion}"
+    implementation "io.opencensus:opencensus-exporter-stats-stackdriver:${opencensusVersion}"
 
     implementation "org.apache.commons:commons-math3:3.6.1"
 

--- a/end2end-test-examples/echo-client/build.gradle
+++ b/end2end-test-examples/echo-client/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'io.grpc'
-version '2.2-SNAPSHOT'
+version '2.3-SNAPSHOT'
 
 sourceCompatibility = 1.9
 targetCompatibility = 1.9

--- a/end2end-test-examples/echo-client/build.gradle
+++ b/end2end-test-examples/echo-client/build.gradle
@@ -10,7 +10,7 @@ version '2.2-SNAPSHOT'
 sourceCompatibility = 1.9
 targetCompatibility = 1.9
 
-def grpcVersion = '1.45.0'
+def grpcVersion = '1.34.1'
 def protobufVersion = '3.19.4'
 def protocVersion = protobufVersion
 def opencensusVersion = '0.31.0'

--- a/end2end-test-examples/echo-client/pom.xml
+++ b/end2end-test-examples/echo-client/pom.xml
@@ -22,6 +22,7 @@
     <grpc.version>1.34.1</grpc.version>
     <protobuf.version>3.9.0</protobuf.version>
     <protoc.version>${protobuf.version}</protoc.version>
+    <opencensus.version>0.31.0</opencensus.version>
   </properties>
 
   <dependencyManagement>
@@ -87,6 +88,26 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>
       <version>3.6.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opencensus</groupId>
+      <artifactId>opencensus-api</artifactId>
+      <version>${opencensus.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opencensus</groupId>
+      <artifactId>opencensus-impl</artifactId>
+      <version>${opencensus.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opencensus</groupId>
+      <artifactId>opencensus-exporter-metrics-ocagent</artifactId>
+      <version>${opencensus.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opencensus</groupId>
+      <artifactId>opencensus-exporter-stats-stackdriver</artifactId>
+      <version>${opencensus.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/end2end-test-examples/echo-client/pom.xml
+++ b/end2end-test-examples/echo-client/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.grpc</groupId>
   <artifactId>echo-client</artifactId>
-  <version>2.2-SNAPSHOT</version>
+  <version>2.3-SNAPSHOT</version>
   <inceptionYear>2019</inceptionYear>
   <licenses>
     <license>

--- a/end2end-test-examples/echo-client/pom.xml
+++ b/end2end-test-examples/echo-client/pom.xml
@@ -101,11 +101,6 @@
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
-      <artifactId>opencensus-exporter-metrics-ocagent</artifactId>
-      <version>${opencensus.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-stats-stackdriver</artifactId>
       <version>${opencensus.version}</version>
     </dependency>

--- a/end2end-test-examples/echo-client/src/main/java/io/grpc/echo/Args.java
+++ b/end2end-test-examples/echo-client/src/main/java/io/grpc/echo/Args.java
@@ -41,6 +41,9 @@ public class Args {
   final int logMaxSize;
   final int logMaxFiles;
   final boolean disableConsoleLog;
+  final String metricName;
+  final String metricTaskPrefix;
+  final String metricProbeName;
 
   Args(String[] args) throws ArgumentParserException {
     ArgumentParser parser =
@@ -79,6 +82,9 @@ public class Args {
     parser.addArgument("--logMaxSize").type(Integer.class).setDefault(0);
     parser.addArgument("--logMaxFiles").type(Integer.class).setDefault(0);
     parser.addArgument("--disableConsoleLog").type(Boolean.class).setDefault(false);
+    parser.addArgument("--metricName").type(String.class).setDefault("");
+    parser.addArgument("--metricTaskPrefix").type(String.class).setDefault("");
+    parser.addArgument("--metricProbeName").type(String.class).setDefault("");
 
     Namespace ns = parser.parseArgs(args);
 
@@ -113,6 +119,10 @@ public class Args {
     logMaxSize = ns.getInt("logMaxSize");
     logMaxFiles = ns.getInt("logMaxFiles");
     disableConsoleLog = ns.getBoolean("disableConsoleLog");
+    metricName = ns.getString("metricName");
+    metricTaskPrefix = ns.getString("metricTaskPrefix");
+    metricProbeName = ns.getString("metricProbeName");
+
     distrib = (qps > 0) ? new PoissonDistribution(1000/qps) : null;
   }
 }

--- a/end2end-test-examples/echo-client/src/main/java/io/grpc/echo/EchoClient.java
+++ b/end2end-test-examples/echo-client/src/main/java/io/grpc/echo/EchoClient.java
@@ -1,12 +1,6 @@
 package io.grpc.echo;
 
-import io.grpc.Channel;
-import io.grpc.ClientInterceptor;
-import io.grpc.ClientInterceptors;
-import io.grpc.ConnectivityState;
-import io.grpc.ManagedChannel;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
+import io.grpc.*;
 import io.grpc.echo.Echo.EchoResponse;
 import io.grpc.echo.Echo.BatchEchoRequest;
 import io.grpc.echo.Echo.BatchEchoResponse;
@@ -18,15 +12,20 @@ import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.shaded.io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.grpc.stub.StreamObserver;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.net.ssl.SSLException;
+
+import io.opencensus.metrics.*;
 import org.HdrHistogram.Histogram;
 
 public class EchoClient {
@@ -44,8 +43,14 @@ public class EchoClient {
 
   private int rr;
 
+  private MetricRegistry metricRegistry;
+  private Map<String, Map<Boolean, AtomicLong>> errorCounts = new ConcurrentHashMap<>();
+  final private String OTHER_STATUS = "OTHER";
+
   public EchoClient(Args args) throws SSLException {
     this.args = args;
+
+    setUpMetrics();
 
     channels = new ManagedChannel[args.numChannels];
     asyncStubs = new GrpcCloudapiStub[args.numChannels];
@@ -75,6 +80,78 @@ public class EchoClient {
           blockingStub = blockingStub.withCompression(args.reqComp);
         }
         asyncStubs[i] = asyncStubs[i].withCompression(args.reqComp);
+      }
+    }
+  }
+
+  private void setUpMetrics() {
+    if (args.metricName.isEmpty()) {
+      return;
+    }
+    metricRegistry = Metrics.getMetricRegistry();
+
+    String hostname = "unknown";
+    try {
+      hostname = InetAddress.getLocalHost().getHostName();
+    } catch (UnknownHostException e) {
+      logger.log(Level.WARNING, "Cannot get hostname", e);
+    }
+
+    Map<LabelKey, LabelValue> labels = new HashMap<>();
+    labels.put(
+            LabelKey.create("prober_task", "Prober task identifier"),
+            LabelValue.create(args.metricTaskPrefix + ProcessHandle.current().pid() + "@" + hostname)
+    );
+    if (!args.metricProbeName.isEmpty()) {
+      labels.put(
+              LabelKey.create("probe_name", "Prober name"),
+              LabelValue.create(args.metricProbeName)
+      );
+    }
+
+    final DerivedLongGauge presenceMetric =
+            metricRegistry.addDerivedLongGauge(args.metricName + "/presence", MetricOptions.builder()
+                    .setDescription("Number of prober instances running")
+                    .setUnit("1")
+                    .setConstantLabels(labels)
+                    .build());
+
+    final List<LabelKey> errorKeys = new ArrayList<>();
+    errorKeys.add(LabelKey.create("code", "The gRPC error code"));
+    errorKeys.add(LabelKey.create("sawGfe", "Whether Google load balancer response headers were present"));
+
+    final DerivedLongCumulative errorsMetric =
+            metricRegistry.addDerivedLongCumulative(args.metricName + "/error-count", MetricOptions.builder()
+                    .setDescription("Number of RPC errors")
+                    .setUnit("1")
+                    .setConstantLabels(labels)
+                    .setLabelKeys(errorKeys)
+                    .build());
+
+    final List<LabelValue> emptyValues = new ArrayList<>();
+    presenceMetric.removeTimeSeries(emptyValues);
+    presenceMetric.createTimeSeries(emptyValues, this, echoClient -> 1L);
+
+    final List<String> reportedStatuses = new ArrayList<>();
+    reportedStatuses.add(Status.Code.DEADLINE_EXCEEDED.toString());
+    reportedStatuses.add(Status.Code.UNAVAILABLE.toString());
+    reportedStatuses.add(Status.Code.CANCELLED.toString());
+    reportedStatuses.add(Status.Code.ABORTED.toString());
+    reportedStatuses.add(Status.Code.INTERNAL.toString());
+    reportedStatuses.add(OTHER_STATUS);
+
+    for (String status : reportedStatuses) {
+      errorCounts.putIfAbsent(status, new ConcurrentHashMap<>());
+      errorCounts.get(status).putIfAbsent(false, new AtomicLong());
+      errorCounts.get(status).putIfAbsent(true, new AtomicLong());
+
+      for (boolean sawGfe : Arrays.asList(false, true)) {
+        final List<LabelValue> errorValues = new ArrayList<>();
+        errorValues.add(LabelValue.create(status));
+        errorValues.add(LabelValue.create(String.valueOf(sawGfe)));
+
+        errorsMetric.removeTimeSeries(errorValues);
+        errorsMetric.createTimeSeries(errorValues, this, echoClient -> echoClient.reportRpcErrors(status, sawGfe));
       }
     }
   }
@@ -111,6 +188,10 @@ public class EchoClient {
     Channel channel = managedChannel;
     if (HeaderClientInterceptor.needsInterception(args)) {
       ClientInterceptor interceptor = new HeaderClientInterceptor(args);
+      channel = ClientInterceptors.intercept(channel, interceptor);
+    }
+    if (MetricsClientInterceptor.needsInterception(args)) {
+      ClientInterceptor interceptor = new MetricsClientInterceptor(this);
       channel = ClientInterceptors.intercept(channel, interceptor);
     }
     if (i == 0) {
@@ -259,5 +340,26 @@ public class EchoClient {
       blockingEcho(histogram);
     }
     //logger.info("Sync request: sent rpc#: " + rpcIndex);
+  }
+
+  private String statusToMetricLabel(Status status) {
+    switch (status.getCode()) {
+      case ABORTED:
+      case CANCELLED:
+      case DEADLINE_EXCEEDED:
+      case UNAVAILABLE:
+      case INTERNAL:
+        return status.getCode().toString();
+      default:
+        return OTHER_STATUS;
+    }
+  }
+
+  void registerRpcError(Status status, boolean sawGfe) {
+    errorCounts.get(statusToMetricLabel(status)).get(sawGfe).incrementAndGet();
+  }
+
+  private long reportRpcErrors(String status, boolean sawGfe) {
+    return errorCounts.get(status).get(sawGfe).get();
   }
 }

--- a/end2end-test-examples/echo-client/src/main/java/io/grpc/echo/MetricsClientInterceptor.java
+++ b/end2end-test-examples/echo-client/src/main/java/io/grpc/echo/MetricsClientInterceptor.java
@@ -1,0 +1,45 @@
+package io.grpc.echo;
+
+import io.grpc.*;
+
+public class MetricsClientInterceptor implements ClientInterceptor {
+    final private EchoClient echoClient;
+
+    public MetricsClientInterceptor(EchoClient echoClient) {
+        this.echoClient = echoClient;
+    }
+
+    public static boolean needsInterception(Args args) {
+        return !args.metricName.isEmpty();
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+        return new ForwardingClientCall.SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
+            private boolean sawGfe = false;
+
+            @Override
+            public void start(Listener<RespT> responseListener, Metadata headers) {
+                headers.put(Metadata.Key.of("x-return-encrypted-headers", Metadata.ASCII_STRING_MARSHALLER), "true");
+                super.start(new ForwardingClientCallListener.SimpleForwardingClientCallListener<>(responseListener) {
+                    @Override
+                    public void onHeaders(Metadata headers) {
+                        if (!sawGfe) {
+                            sawGfe = headers.containsKey(Metadata.Key.of("x-encrypted-debug-headers", Metadata.ASCII_STRING_MARSHALLER));
+                        }
+                        super.onHeaders(headers);
+                    }
+
+                    @Override
+                    public void onClose(Status status, Metadata trailers) {
+                        // Report status, saw GFE
+                        if (!status.equals(Status.OK)) {
+                            echoClient.registerRpcError(status, sawGfe);
+                        }
+                        super.onClose(status, trailers);
+                    }
+                }, headers);
+            }
+        };
+    }
+}

--- a/end2end-test-examples/echo-client/src/main/java/io/grpc/echo/TestMain.java
+++ b/end2end-test-examples/echo-client/src/main/java/io/grpc/echo/TestMain.java
@@ -111,7 +111,7 @@ public class TestMain {
     printResult(args, totalPayloadSize, totalRecvTime, histogram);
   }
 
-  private static void execTask(Args argObj) throws InterruptedException, SSLException {
+  private static void execTask(Args argObj) throws InterruptedException, IOException {
     EchoClient client = new EchoClient(argObj);
     try {
       logger.info("Start warm up...");


### PR DESCRIPTION
Add sending metrics to Google Cloud Monitoring when `--metricName` argument is provided:

&lt;metricName>/presence
&lt;metricName>/error-count

