### PR TITLE
Add optional round-robin channel selection for affinity binding calls.

### DIFF
--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpClientCall.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpClientCall.java
@@ -115,7 +115,12 @@ public class GcpClientCall<ReqT, RespT> extends ClientCall<ReqT, RespT> {
             && delegateChannel.getChannelRef(keys.get(0)) != null) {
           key = keys.get(0);
         }
-        delegateChannelRef = delegateChannel.getChannelRef(key);
+
+        if (affinity != null && affinity.getCommand().equals(AffinityConfig.Command.BIND)) {
+          delegateChannelRef = delegateChannel.getChannelRefForBind();
+        } else {
+          delegateChannelRef = delegateChannel.getChannelRef(key);
+        }
         delegateChannelRef.activeStreamsCountIncr();
 
         // Create the client call and do the previous operations.

--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannelOptions.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannelOptions.java
@@ -155,10 +155,13 @@ public class GcpManagedChannelOptions {
     // If every channel in the pool has at least this amount of concurrent streams then a new channel will be created
     // in the pool unless the pool reached its maximum size.
     private final int concurrentStreamsLowWatermark;
+    // Use round-robin channel selection for affinity binding calls.
+    private final boolean useRoundRobinOnBind;
 
     public GcpChannelPoolOptions(Builder builder) {
       maxSize = builder.maxSize;
       concurrentStreamsLowWatermark = builder.concurrentStreamsLowWatermark;
+      useRoundRobinOnBind = builder.useRoundRobinOnBind;
     }
 
     public int getMaxSize() {
@@ -179,9 +182,14 @@ public class GcpManagedChannelOptions {
       return new GcpChannelPoolOptions.Builder(options);
     }
 
+    public boolean isUseRoundRobinOnBind() {
+      return useRoundRobinOnBind;
+    }
+
     public static class Builder {
       private int maxSize = GcpManagedChannel.DEFAULT_MAX_CHANNEL;
       private int concurrentStreamsLowWatermark = GcpManagedChannel.DEFAULT_MAX_STREAM;
+      private boolean useRoundRobinOnBind = false;
 
       public Builder() {}
 
@@ -192,6 +200,7 @@ public class GcpManagedChannelOptions {
         }
         this.maxSize = options.getMaxSize();
         this.concurrentStreamsLowWatermark = options.getConcurrentStreamsLowWatermark();
+        this.useRoundRobinOnBind = options.isUseRoundRobinOnBind();
       }
 
       public GcpChannelPoolOptions build() {
@@ -219,6 +228,16 @@ public class GcpManagedChannelOptions {
        */
       public Builder setConcurrentStreamsLowWatermark(int concurrentStreamsLowWatermark) {
         this.concurrentStreamsLowWatermark = concurrentStreamsLowWatermark;
+        return this;
+      }
+
+      /**
+       * Enables/disables using round-robin channel selection for affinity binding calls.
+       *
+       * @param enabled If true, use round-robin channel selection for affinity binding calls.
+       */
+      public Builder setUseRoundRobinOnBind(boolean enabled) {
+        this.useRoundRobinOnBind = enabled;
         return this;
       }
     }


### PR DESCRIPTION
Currently a binding call (as any other call without an affinity key) gets the least busy channel, i.e. channel that has fewest active streams. The current logic may not suit all the cases for binding new affinity keys in an optimal way.

It works well when the upstream issues bind calls infrequently and uses the affinity keys from these calls immediately. This way the channels used for the bind calls get utilized by the time a next bind call is issued and affinity keys remain balanced across channels.

But if the upstream makes several bind calls one after another and does not use the returned affinity keys right away, then the affinity keys will not be balanced.

For example:

Let's assume we have this situation: we have 3 long running calls on channel 1 and 3 each and 1 call on the channel 2:

| Channels | Affinity keys | Active streams |
| - | - | - |
| 1 | 5 | 3 |
| 2 | 5 | 1 |
| 3 | 5 | 3 |

New bind call arrives and gets routed to channel 2 because it has the fewest active streams.
The bind call returns 5 new affinity keys that is bound to channel 2:

| Channels | Affinity keys | Active streams |
| - | - | - |
| 1 | 5 | 3 |
| 2 | 10 | 1 |
| 3 | 5 | 3 |

Another bind call arrives and gets another 5 new keys:

| Channels | Affinity keys | Active streams |
| - | - | - |
| 1 | 5 | 3 |
| 2 | 15 | 1 |
| 3 | 5 | 3 |

This pattern may be continued to incur more imbalance.

If the upstream always requests the bind calls with a fixed number of affinity keys and never does unbind calls then we can round-robin bind calls to guarantee balanced distribution of affinity keys.

This PR introduces the option to round-robin bind calls.