### PR TITLE
Support 4GiB for GCSIO

### DIFF
--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GcsioClient.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GcsioClient.java
@@ -155,7 +155,7 @@ public class GcsioClient {
       while (receivedSize < totalSize) {
         int r = readChannel.read(buff);
         if (r < 0) break;
-        buff.rewind();
+        buff.clear();
         receivedSize += r;
       }
       long dur = System.currentTimeMillis() - start;

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GcsioClient.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GcsioClient.java
@@ -154,6 +154,7 @@ public class GcsioClient {
       ReadableByteChannel readChannel = gcsfs.open(uri);
       while (receivedSize < totalSize) {
         int r = readChannel.read(buff);
+        logger.warning("R: " + r);
         if (r < 0) break;
         buff.clear();
         receivedSize += r;

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GcsioClient.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GcsioClient.java
@@ -143,22 +143,25 @@ public class GcsioClient {
         new GoogleCloudStorageFileSystem(
             creds,
             GoogleCloudStorageFileSystemOptions.builder().setCloudStorageOptions(gcsOpts).build());
-
-    int size = args.size * 1024;
-    ByteBuffer buff = ByteBuffer.allocate(size);
+    long totalSize = args.size * 1024L;
+    long receivedSize = 0;
+    int buffSize = (args.buffSize == 0 ? 32 * 1024 : args.buffSize) * 1024;
+    ByteBuffer buff = ByteBuffer.allocate(buffSize);
     for (int i = 0; i < args.calls; i++) {
       long start = System.currentTimeMillis();
       String object = objectResolver.Resolve(threadId, i);
       URI uri = URI.create("gs://" + args.bkt + "/" + object);
       ReadableByteChannel readChannel = gcsfs.open(uri);
-      readChannel.read(buff);
-      long dur = System.currentTimeMillis() - start;
-      if (buff.remaining() > 0) {
-        logger.warning("Got remaining bytes: " + buff.remaining());
+      while (receivedSize < totalSize) {
+        int r = readChannel.read(buff);
+        if (r < 0) break;
+        buff.rewind();
+        receivedSize += r;
       }
+      long dur = System.currentTimeMillis() - start;
       buff.clear();
       readChannel.close();
-      results.reportResult(args.bkt, object, size, dur);
+      results.reportResult(args.bkt, object, receivedSize, dur);
     }
 
     gcsfs.close();

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GcsioClient.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/GcsioClient.java
@@ -144,17 +144,16 @@ public class GcsioClient {
             creds,
             GoogleCloudStorageFileSystemOptions.builder().setCloudStorageOptions(gcsOpts).build());
     long totalSize = args.size * 1024L;
-    long receivedSize = 0;
     int buffSize = (args.buffSize == 0 ? 32 * 1024 : args.buffSize) * 1024;
     ByteBuffer buff = ByteBuffer.allocate(buffSize);
     for (int i = 0; i < args.calls; i++) {
+      long receivedSize = 0;
       long start = System.currentTimeMillis();
       String object = objectResolver.Resolve(threadId, i);
       URI uri = URI.create("gs://" + args.bkt + "/" + object);
       ReadableByteChannel readChannel = gcsfs.open(uri);
       while (receivedSize < totalSize) {
         int r = readChannel.read(buff);
-        logger.warning("R: " + r);
         if (r < 0) break;
         buff.clear();
         receivedSize += r;


### PR DESCRIPTION
`int` is not enough. `long` will save us.