### PR TITLE
Bind keys on the fly.

### DIFF
--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannel.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannel.java
@@ -822,7 +822,12 @@ public class GcpManagedChannel extends ManagedChannel {
       return pickLeastBusyChannel(/* forFallback= */ false);
     }
     ChannelRef mappedChannel = affinityKeyToChannelRef.get(key);
-    if (mappedChannel == null || !fallbackEnabled) {
+    if (mappedChannel == null) {
+      ChannelRef channelRef = pickLeastBusyChannel(/*forFallback= */ false);
+      bind(channelRef, Collections.singletonList(key));
+      return channelRef;
+    }
+    if (!fallbackEnabled) {
       return mappedChannel;
     }
     // Look up if the channelRef is not ready.

--- a/grpc-gcp/src/test/java/com/google/cloud/grpc/GcpManagedChannelTest.java
+++ b/grpc-gcp/src/test/java/com/google/cloud/grpc/GcpManagedChannelTest.java
@@ -433,11 +433,9 @@ public final class GcpManagedChannelTest {
 
     cf1.activeStreamsCountDecr(System.nanoTime(), Status.OK, true);
     cf1.activeStreamsCountDecr(System.nanoTime(), Status.OK, true);
+    channelRef = gcpChannel.getChannelRef(key);
     // Even after channel 1 now has less active streams (3) the channel 2 is still mapped for the
     // same key.
-
-    channelRef = gcpChannel.getChannelRef(key);
-    // Should bind on the fly to the least busy channel, which is 2.
     assertThat(channelRef.getId()).isEqualTo(2);
   }
 


### PR DESCRIPTION
Previously, if GcpManagedChannel didn't get a key from a bind call, then it will always return the least busy channel for the key effectively providing no affinity.

But it is not guaranteed that GcpManagedChannel will have a key from a bind call. E.g., an affinity key may be obtained by the upstream by other means.

After this change a key will be mapped to a channel on a bind call or on the first use.