### PR TITLE
Multi-endpoint feature

### DIFF
--- a/grpc-gcp/build.gradle
+++ b/grpc-gcp/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.opencensus:opencensus-api:${opencensusVersion}"
+    implementation "com.google.api:api-common:2.1.5"
 
     compileOnly "org.apache.tomcat:annotations-api:6.0.53" // necessary for Java 9+
 

--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannelOptions.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannelOptions.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import io.opencensus.metrics.LabelKey;
 import io.opencensus.metrics.LabelValue;
 import io.opencensus.metrics.MetricRegistry;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -64,10 +65,10 @@ public class GcpManagedChannelOptions {
   @Override
   public String toString() {
     return String.format(
-        "{channelPoolOptions: %s, metricsOptions: %s, resiliencyOptions: %s}",
+        "{channelPoolOptions: %s, resiliencyOptions: %s, metricsOptions: %s}",
         getChannelPoolOptions(),
-        getMetricsOptions(),
-        getResiliencyOptions()
+        getResiliencyOptions(),
+        getMetricsOptions()
     );
   }
 
@@ -208,8 +209,9 @@ public class GcpManagedChannelOptions {
     @Override
     public String toString() {
       return String.format(
-          "{maxSize: %d, concurrentStreamsLowWatermark: %d, useRoundRobinOnBind: %s}",
+          "{maxSize: %d, minSize: %d, concurrentStreamsLowWatermark: %d, useRoundRobinOnBind: %s}",
           getMaxSize(),
+          getMinSize(),
           getConcurrentStreamsLowWatermark(),
           isUseRoundRobinOnBind()
       );

--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpMultiEndpointChannel.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpMultiEndpointChannel.java
@@ -1,0 +1,402 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.grpc;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import com.google.cloud.grpc.GcpManagedChannelOptions.GcpChannelPoolOptions;
+import com.google.cloud.grpc.GcpManagedChannelOptions.GcpMetricsOptions;
+import com.google.cloud.grpc.multiendpoint.MultiEndpoint;
+import com.google.cloud.grpc.proto.ApiConfig;
+import com.google.common.base.Preconditions;
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.ClientCall.Listener;
+import io.grpc.ConnectivityState;
+import io.grpc.Grpc;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.opencensus.metrics.LabelKey;
+import io.opencensus.metrics.LabelValue;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The purpose of GcpMultiEndpointChannel is twofold:
+ *
+ * <ol>
+ *   <li>Fallback to an alternative endpoint (host:port) of a gRPC service when the original
+ *   endpoint is completely unavailable.
+ *   <li>Be able to route an RPC call to a specific group of endpoints.
+ * </ol>
+ *
+ * <p>A group of endpoints is called a {@link MultiEndpoint} and is essentially a list of endpoints
+ * where priority is defined by the position in the list with the first endpoint having top
+ * priority. A MultiEndpoint tracks endpoints' availability. When a MultiEndpoint is picked for an
+ * RPC call, it picks the top priority endpoint that is currently available. More information on
+ * the {@link MultiEndpoint} class.
+ *
+ * <p>GcpMultiEndpointChannel can have one or more MultiEndpoint identified by its name -- arbitrary
+ * string provided in the {@link GcpMultiEndpointOptions} when configuring MultiEndpoints. This name
+ * can be used to route an RPC call to this MultiEndpoint by setting the {@link #ME_KEY} key value
+ * of the RPC {@link CallOptions}.
+ *
+ * <p>GcpMultiEndpointChannel receives a list of GcpMultiEndpointOptions for initial configuration.
+ * An updated configuration can be provided at any time later using
+ * {@link GcpMultiEndpointChannel#setMultiEndpoints(List)}. The first item in the
+ * GcpMultiEndpointOptions list defines the default MultiEndpoint that will be used when no
+ * MultiEndpoint name is provided with an RPC call.
+ *
+ * <p>Example configuration:
+ * <ul>
+ *   <li>
+ *     MultiEndpoint named "default" with endpoints:
+ *     <ol>
+ *       <li>service.example.com:443</li>
+ *       <li>service-fallback.example.com:443</li>
+ *     </ol>
+ *   </li>
+ *   <li>
+ *     MultiEndpoint named "read" with endpoints:
+ *     <ol>
+ *       <li>ro-service.example.com:443</li>
+ *       <li>service-fallback.example.com:443</li>
+ *       <li>service.example.com:443</li>
+ *     </ol>
+ *   </li>
+ * </ul>
+ *
+ * <p>Let's assume we have a service with read and write operations and the following backends:
+ * <ul>
+ *   <li>service.example.com -- the main set of backends supporting all operations</li>
+ *   <li>service-fallback.example.com -- read-write replica supporting all operations</li>
+ *   <li>ro-service.example.com -- read-only replica supporting only read operations</li>
+ * </ul>
+ *
+ * <p>With the configuration above GcpMultiEndpointChannel will use the "default" MultiEndpoint by
+ * default. It means that RPC calls by default will use the main endpoint and if it is not available
+ * then the read-write replica.
+ *
+ * <p>To offload some read calls to the read-only replica we can specify "read" MultiEndpoint in
+ * the CallOptions. Then these calls will use the read-only replica endpoint and if it is not
+ * available then the read-write replica and if it is also not available then the main endpoint.
+ *
+ * <p>GcpMultiEndpointChannel creates a {@link GcpManagedChannel} channel pool for every unique
+ * endpoint. For the example above three channel pools will be created.
+ */
+public class GcpMultiEndpointChannel extends ManagedChannel {
+
+  public static final CallOptions.Key<String> ME_KEY = CallOptions.Key.create("MultiEndpoint");
+  private final LabelKey endpointKey =
+      LabelKey.create("endpoint", "Endpoint address.");
+  private final Map<String, MultiEndpoint> multiEndpoints = new ConcurrentHashMap<>();
+  private MultiEndpoint defaultMultiEndpoint;
+  private final ApiConfig apiConfig;
+  private final GcpManagedChannelOptions gcpManagedChannelOptions;
+
+  private final Map<String, GcpManagedChannel> pools = new ConcurrentHashMap<>();
+
+  /**
+   * Constructor for {@link GcpMultiEndpointChannel}.
+   *
+   * @param meOptions list of MultiEndpoint configurations.
+   * @param apiConfig the ApiConfig object for configuring GcpManagedChannel.
+   * @param gcpManagedChannelOptions the options for GcpManagedChannel.
+   */
+  public GcpMultiEndpointChannel(
+      List<GcpMultiEndpointOptions> meOptions,
+      ApiConfig apiConfig,
+      GcpManagedChannelOptions gcpManagedChannelOptions) {
+    this.apiConfig = apiConfig;
+    this.gcpManagedChannelOptions = gcpManagedChannelOptions;
+    setMultiEndpoints(meOptions);
+  }
+
+  private class EndpointStateMonitor implements Runnable {
+
+    private final ManagedChannel channel;
+    private final String endpoint;
+
+    private EndpointStateMonitor(ManagedChannel channel, String endpoint) {
+      this.endpoint = endpoint;
+      this.channel = channel;
+      run();
+    }
+
+    @Override
+    public void run() {
+      if (channel == null) {
+        return;
+      }
+      ConnectivityState newState = checkPoolState(channel, endpoint);
+      if (newState != ConnectivityState.SHUTDOWN) {
+        channel.notifyWhenStateChanged(newState, this);
+      }
+    }
+  }
+
+  // Checks and returns channel pool state. Also notifies all MultiEndpoints of the pool state.
+  private ConnectivityState checkPoolState(ManagedChannel channel, String endpoint) {
+    ConnectivityState state = channel.getState(false);
+    // Update endpoint state in all multiendpoints.
+    for (MultiEndpoint me : multiEndpoints.values()) {
+      me.setEndpointAvailable(endpoint, state.equals(ConnectivityState.READY));
+    }
+    return state;
+  }
+
+  private GcpManagedChannelOptions prepareGcpManagedChannelConfig(
+      GcpManagedChannelOptions gcpOptions, String endpoint) {
+    final GcpMetricsOptions.Builder metricsOptions = GcpMetricsOptions.newBuilder(
+        gcpOptions.getMetricsOptions()
+    );
+
+    final List<LabelKey> labelKeys = new ArrayList<>(metricsOptions.build().getLabelKeys());
+    final List<LabelValue> labelValues = new ArrayList<>(metricsOptions.build().getLabelValues());
+
+    labelKeys.add(endpointKey);
+    labelValues.add(LabelValue.create(endpoint));
+
+    // Make sure the pool will have at least 1 channel always connected. If maximum size > 1 then we
+    // want at least 2 channels or square root of maximum channels whichever is larger.
+    // Do not override if minSize is already specified as > 0.
+    final GcpChannelPoolOptions.Builder poolOptions = GcpChannelPoolOptions.newBuilder(
+        gcpOptions.getChannelPoolOptions()
+    );
+    if (poolOptions.build().getMinSize() < 1) {
+      int minSize = Math.min(2, poolOptions.build().getMaxSize());
+      minSize = Math.max(minSize, ((int) Math.sqrt(poolOptions.build().getMaxSize())));
+      poolOptions.setMinSize(minSize);
+    }
+
+    return GcpManagedChannelOptions.newBuilder(gcpOptions)
+        .withChannelPoolOptions(poolOptions.build())
+        .withMetricsOptions(metricsOptions.withLabels(labelKeys, labelValues).build())
+        .build();
+  }
+
+  /**
+   * Update the list of MultiEndpoint configurations.
+   *
+   * <p>MultiEndpoints are matched with the current ones by name.
+   * <ul>
+   * <li>If a current MultiEndpoint is missing in the updated list, the MultiEndpoint will be
+   * removed.
+   * <li>A new MultiEndpoint will be created for every new name in the list.
+   * <li>For an existing MultiEndpoint only its endpoints will be updated (no recovery timeout
+   * change).
+   * </ul>
+   *
+   * <p>Endpoints are matched by the endpoint address (usually in the form of address:port).
+   * <ul>
+   * <li>If an existing endpoint is not used by any MultiEndpoint in the updated list, then the
+   * channel poll for this endpoint will be shutdown.
+   * <li>A channel pool will be created for every new endpoint.
+   * <li>For an existing endpoint nothing will change (the channel pool will not be re-created, thus
+   * no channel credentials change, nor channel configurator change).
+   * </ul>
+   */
+  public void setMultiEndpoints(List<GcpMultiEndpointOptions> meOptions) {
+    Preconditions.checkNotNull(meOptions);
+    Preconditions.checkArgument(!meOptions.isEmpty(), "MultiEndpoints list is empty");
+    Set<String> currentMultiEndpoints = new HashSet<>();
+    Set<String> currentEndpoints = new HashSet<>();
+    meOptions.forEach(options -> {
+      currentMultiEndpoints.add(options.getName());
+      // Create or update MultiEndpoint
+      if (multiEndpoints.containsKey(options.getName())) {
+        multiEndpoints.get(options.getName()).setEndpoints(options.getEndpoints());
+      } else {
+        multiEndpoints.put(options.getName(),
+            (new MultiEndpoint.Builder(options.getEndpoints()))
+                .withRecoveryTimeout(options.getRecoveryTimeout())
+                .build());
+      }
+    });
+    // Must have all multiendpoints before initializing the pools so that all multiendpoints
+    // can get status update of every pool.
+    meOptions.forEach(options -> {
+      // Create missing pools
+      options.getEndpoints().forEach(endpoint -> {
+        currentEndpoints.add(endpoint);
+        pools.computeIfAbsent(endpoint, e -> {
+          ManagedChannelBuilder<?> managedChannelBuilder;
+          if (options.getChannelCredentials() != null) {
+            managedChannelBuilder = Grpc.newChannelBuilder(e, options.getChannelCredentials());
+          } else {
+            String serviceAddress;
+            int port;
+            int colon = e.lastIndexOf(':');
+            if (colon < 0) {
+              serviceAddress = e;
+              // Assume https by default.
+              port = 443;
+            } else {
+              serviceAddress = e.substring(0, colon);
+              port = Integer.parseInt(e.substring(colon + 1));
+            }
+            managedChannelBuilder = ManagedChannelBuilder.forAddress(serviceAddress, port);
+          }
+          if (options.getChannelConfigurator() != null) {
+            managedChannelBuilder = options.getChannelConfigurator().apply(managedChannelBuilder);
+          }
+
+          GcpManagedChannel channel = new GcpManagedChannel(
+              managedChannelBuilder,
+              apiConfig,
+              // Add endpoint to metric labels.
+              prepareGcpManagedChannelConfig(gcpManagedChannelOptions, e));
+          // Start monitoring the pool state.
+          new EndpointStateMonitor(channel, e);
+          return channel;
+        });
+        // Communicate current state to MultiEndpoints.
+        checkPoolState(pools.get(endpoint), endpoint);
+      });
+    });
+    defaultMultiEndpoint = multiEndpoints.get(meOptions.get(0).getName());
+
+    // Remove obsolete multiendpoints.
+    multiEndpoints.keySet().removeIf(name -> !currentMultiEndpoints.contains(name));
+
+    // Shutdown and remove the pools not present in options.
+    for (String endpoint : pools.keySet()) {
+      if (!currentEndpoints.contains(endpoint)) {
+        pools.get(endpoint).shutdown();
+        pools.remove(endpoint);
+      }
+    }
+  }
+
+  /**
+   * Initiates an orderly shutdown in which preexisting calls continue but new calls are immediately
+   * cancelled.
+   *
+   * @return this
+   * @since 1.0.0
+   */
+  @Override
+  public ManagedChannel shutdown() {
+    pools.values().forEach(GcpManagedChannel::shutdown);
+    return this;
+  }
+
+  /**
+   * Returns whether the channel is shutdown. Shutdown channels immediately cancel any new calls,
+   * but may still have some calls being processed.
+   *
+   * @see #shutdown()
+   * @see #isTerminated()
+   * @since 1.0.0
+   */
+  @Override
+  public boolean isShutdown() {
+    return pools.values().stream().allMatch(GcpManagedChannel::isShutdown);
+  }
+
+  /**
+   * Returns whether the channel is terminated. Terminated channels have no running calls and
+   * relevant resources released (like TCP connections).
+   *
+   * @see #isShutdown()
+   * @since 1.0.0
+   */
+  @Override
+  public boolean isTerminated() {
+    return pools.values().stream().allMatch(GcpManagedChannel::isTerminated);
+  }
+
+  /**
+   * Initiates a forceful shutdown in which preexisting and new calls are cancelled. Although
+   * forceful, the shutdown process is still not instantaneous; {@link #isTerminated()} will likely
+   * return {@code false} immediately after this method returns.
+   *
+   * @return this
+   * @since 1.0.0
+   */
+  @Override
+  public ManagedChannel shutdownNow() {
+    pools.values().forEach(GcpManagedChannel::shutdownNow);
+    return this;
+  }
+
+  /**
+   * Waits for the channel to become terminated, giving up if the timeout is reached.
+   *
+   * @return whether the channel is terminated, as would be done by {@link #isTerminated()}.
+   * @since 1.0.0
+   */
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    long endTimeNanos = System.nanoTime() + unit.toNanos(timeout);
+    for (GcpManagedChannel gcpManagedChannel : pools.values()) {
+      if (gcpManagedChannel.isTerminated()) {
+        continue;
+      }
+      long awaitTimeNanos = endTimeNanos - System.nanoTime();
+      if (awaitTimeNanos <= 0) {
+        break;
+      }
+      gcpManagedChannel.awaitTermination(awaitTimeNanos, NANOSECONDS);
+    }
+    return isTerminated();
+  }
+
+  /**
+   * Check the value of {@link #ME_KEY} key in the {@link CallOptions} and if found use
+   * the MultiEndpoint with the same name for this call.
+   *
+   * <p>Create a {@link ClientCall} to the remote operation specified by the given {@link
+   * MethodDescriptor}. The returned {@link ClientCall} does not trigger any remote behavior until
+   * {@link ClientCall#start(Listener, Metadata)} is invoked.
+   *
+   * @param methodDescriptor describes the name and parameter types of the operation to call.
+   * @param callOptions runtime options to be applied to this call.
+   * @return a {@link ClientCall} bound to the specified method.
+   * @since 1.0.0
+   */
+  @Override
+  public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+      MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
+    final String multiEndpointKey = callOptions.getOption(ME_KEY);
+    MultiEndpoint me = defaultMultiEndpoint;
+    if (multiEndpointKey != null) {
+      me = multiEndpoints.getOrDefault(multiEndpointKey, defaultMultiEndpoint);
+    }
+    return pools.get(me.getCurrentId()).newCall(methodDescriptor, callOptions);
+  }
+
+  /**
+   * The authority of the destination this channel connects to. Typically this is in the format
+   * {@code host:port}.
+   *
+   * This may return different values over time because MultiEndpoint may switch between endpoints.
+   *
+   * @since 1.0.0
+   */
+  @Override
+  public String authority() {
+    return pools.get(defaultMultiEndpoint.getCurrentId()).authority();
+  }
+}

--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpMultiEndpointOptions.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpMultiEndpointOptions.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.grpc;
+
+import com.google.api.core.ApiFunction;
+import com.google.cloud.grpc.multiendpoint.MultiEndpoint;
+import com.google.common.base.Preconditions;
+import io.grpc.ChannelCredentials;
+import io.grpc.ManagedChannelBuilder;
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * {@link MultiEndpoint} configuration for the {@link GcpMultiEndpointChannel}.
+ */
+public class GcpMultiEndpointOptions {
+
+  private final String name;
+  private final List<String> endpoints;
+  private final ApiFunction<ManagedChannelBuilder<?>, ManagedChannelBuilder<?>> channelConfigurator;
+  private final ChannelCredentials channelCredentials;
+  private final Duration recoveryTimeout;
+
+  public static String DEFAULT_NAME = "default";
+
+  public GcpMultiEndpointOptions(Builder builder) {
+    this.name = builder.name;
+    this.endpoints = builder.endpoints;
+    this.channelConfigurator = builder.channelConfigurator;
+    this.channelCredentials = builder.channelCredentials;
+    this.recoveryTimeout = builder.recoveryTimeout;
+  }
+
+  /**
+   * Creates a new GcpMultiEndpointOptions.Builder.
+   *
+   * @param endpoints list of endpoints for the MultiEndpoint.
+   */
+  public static Builder newBuilder(List<String> endpoints) {
+    return new Builder(endpoints);
+  }
+
+  /**
+   * Creates a new GcpMultiEndpointOptions.Builder from GcpMultiEndpointOptions.
+   */
+  public static Builder newBuilder(GcpMultiEndpointOptions options) {
+    return new Builder(options);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public List<String> getEndpoints() {
+    return endpoints;
+  }
+
+  public ApiFunction<ManagedChannelBuilder<?>, ManagedChannelBuilder<?>> getChannelConfigurator() {
+    return channelConfigurator;
+  }
+
+  public ChannelCredentials getChannelCredentials() {
+    return channelCredentials;
+  }
+
+  public Duration getRecoveryTimeout() {
+    return recoveryTimeout;
+  }
+
+  public static class Builder {
+
+    private String name = GcpMultiEndpointOptions.DEFAULT_NAME;
+    private List<String> endpoints;
+    private ApiFunction<ManagedChannelBuilder<?>, ManagedChannelBuilder<?>> channelConfigurator;
+    private ChannelCredentials channelCredentials;
+    private Duration recoveryTimeout = Duration.ZERO;
+
+    public Builder(List<String> endpoints) {
+      setEndpoints(endpoints);
+    }
+
+    public Builder(GcpMultiEndpointOptions options) {
+      this.name = options.getName();
+      this.endpoints = options.getEndpoints();
+      this.channelConfigurator = options.getChannelConfigurator();
+      this.channelCredentials = options.getChannelCredentials();
+      this.recoveryTimeout = options.getRecoveryTimeout();
+    }
+
+    public GcpMultiEndpointOptions build() {
+      return new GcpMultiEndpointOptions(this);
+    }
+
+    private void setEndpoints(List<String> endpoints) {
+      Preconditions.checkNotNull(endpoints);
+      Preconditions.checkArgument(
+          !endpoints.isEmpty(), "At least one endpoint must be specified.");
+      Preconditions.checkArgument(
+          endpoints.stream().noneMatch(s -> s.trim().isEmpty()), "No empty endpoints allowed.");
+      this.endpoints = endpoints;
+    }
+
+    /**
+     * Sets the name of the MultiEndpoint.
+     *
+     * @param name MultiEndpoint name.
+     */
+    public GcpMultiEndpointOptions.Builder withName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the endpoints of the MultiEndpoint.
+     *
+     * @param endpoints List of endpoints in the form of host:port in descending priority order.
+     */
+    public GcpMultiEndpointOptions.Builder withEndpoints(List<String> endpoints) {
+      this.setEndpoints(endpoints);
+      return this;
+    }
+
+    /**
+     * Sets the channel configurator for the MultiEndpoint channel pool.
+     *
+     * @param channelConfigurator function to perform on the ManagedChannelBuilder in the channel
+     * pool.
+     */
+    public GcpMultiEndpointOptions.Builder withChannelConfigurator(
+        ApiFunction<ManagedChannelBuilder<?>, ManagedChannelBuilder<?>> channelConfigurator) {
+      this.channelConfigurator = channelConfigurator;
+      return this;
+    }
+
+    /**
+     * Sets the channel credentials to use in the MultiEndpoint channel pool.
+     *
+     * @param channelCredentials channel credentials.
+     */
+    public GcpMultiEndpointOptions.Builder withChannelCredentials(
+        ChannelCredentials channelCredentials) {
+      this.channelCredentials = channelCredentials;
+      return this;
+    }
+
+    /**
+     * Sets the recovery timeout for the MultiEndpoint. See more info in the {@link MultiEndpoint}.
+     *
+     * @param recoveryTimeout recovery timeout.
+     */
+    public GcpMultiEndpointOptions.Builder withRecoveryTimeout(Duration recoveryTimeout) {
+      this.recoveryTimeout = recoveryTimeout;
+      return this;
+    }
+  }
+}

--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/multiendpoint/Endpoint.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/multiendpoint/Endpoint.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.grpc.multiendpoint;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import java.util.concurrent.ScheduledFuture;
+
+/**
+ * Endpoint holds an endpoint's state, priority and a future of upcoming state change.
+ */
+@CheckReturnValue
+final class Endpoint {
+
+  /**
+   * Holds a state of an endpoint.
+   */
+  public enum EndpointState {
+    UNAVAILABLE,
+    AVAILABLE,
+    RECOVERING,
+  }
+
+  private final String id;
+  private EndpointState state;
+  private int priority;
+  private ScheduledFuture<?> changeStateFuture;
+
+  public Endpoint(String id, EndpointState state, int priority) {
+    this.id = id;
+    this.priority = priority;
+    this.state = state;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public EndpointState getState() {
+    return state;
+  }
+
+  public int getPriority() {
+    return priority;
+  }
+
+  public void setState(EndpointState state) {
+    this.state = state;
+  }
+
+  public void setPriority(int priority) {
+    this.priority = priority;
+  }
+
+  public synchronized void setChangeStateFuture(ScheduledFuture<?> future) {
+    resetStateChangeFuture();
+    this.changeStateFuture = future;
+  }
+
+  public synchronized void resetStateChangeFuture() {
+    if (changeStateFuture != null) {
+      changeStateFuture.cancel(true);
+    }
+  }
+}

--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/multiendpoint/MultiEndpoint.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/multiendpoint/MultiEndpoint.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.grpc.multiendpoint;
+
+import static java.util.Comparator.comparingInt;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import com.google.cloud.grpc.multiendpoint.Endpoint.EndpointState;
+import com.google.common.base.Preconditions;
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+/**
+ * MultiEndpoint holds a list of endpoints, tracks their availability and defines the current
+ * endpoint. An endpoint has a priority defined by its position in the list (first item has top
+ * priority). MultiEndpoint returns top priority endpoint that is available as current. If no
+ * endpoint is available, MultiEndpoint returns the top priority endpoint.
+ *
+ * <p>Sometimes switching between endpoints can be costly, and it is worth to wait for some time
+ * after current endpoint becomes unavailable. For this case, use {@link
+ * Builder#withRecoveryTimeout} to set the recovery timeout. MultiEndpoint will keep the current
+ * endpoint for up to recovery timeout after it became unavailable to give it some time to recover.
+ *
+ * <p>The list of endpoints can be changed at any time with {@link #setEndpoints} method.
+ * MultiEndpoint will preserve endpoints' state and update their priority according to their new
+ * positions.
+ *
+ * <p>The initial state of endpoint is "unavailable" or "recovering" if using recovery timeout.
+ */
+@CheckReturnValue
+public final class MultiEndpoint {
+  @GuardedBy("this")
+  private final Map<String, Endpoint> endpointsMap = new HashMap<>();
+
+  @GuardedBy("this")
+  private String currentId;
+
+  private final Duration recoveryTimeout;
+  private final boolean recoveryEnabled;
+
+  private final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+
+  private MultiEndpoint(Builder builder) {
+    this.recoveryTimeout = builder.recoveryTimeout;
+    this.recoveryEnabled =
+        !builder.recoveryTimeout.isNegative() && !builder.recoveryTimeout.isZero();
+    this.setEndpoints(builder.endpoints);
+  }
+
+  /** Builder for MultiEndpoint. */
+  public static final class Builder {
+    private final List<String> endpoints;
+    private Duration recoveryTimeout = Duration.ZERO;
+
+    public Builder(List<String> endpoints) {
+      Preconditions.checkNotNull(endpoints);
+      Preconditions.checkArgument(!endpoints.isEmpty(), "Endpoints list must not be empty.");
+      this.endpoints = endpoints;
+    }
+
+    /**
+     * MultiEndpoint will keep the current endpoint for up to recovery timeout after it became
+     * unavailable to give it some time to recover.
+     */
+    public Builder withRecoveryTimeout(Duration timeout) {
+      Preconditions.checkNotNull(timeout);
+      this.recoveryTimeout = timeout;
+      return this;
+    }
+
+    public MultiEndpoint build() {
+      return new MultiEndpoint(this);
+    }
+  }
+
+  /**
+   * Returns current endpoint id.
+   *
+   * <p>Note that the read is not synchronized and in case of a race condition there is a chance of
+   * getting an outdated current id.
+   */
+  @SuppressWarnings("GuardedBy")
+  public String getCurrentId() {
+    return currentId;
+  }
+
+  private synchronized void setEndpointStateInternal(String endpointId, EndpointState state) {
+    Endpoint endpoint = endpointsMap.get(endpointId);
+    if (endpoint != null) {
+      endpoint.setState(state);
+      maybeFallback();
+    }
+  }
+
+  /** Inform MultiEndpoint when an endpoint becomes available or unavailable. */
+  public synchronized void setEndpointAvailable(String endpointId, boolean available) {
+    setEndpointState(endpointId, available ? EndpointState.AVAILABLE : EndpointState.UNAVAILABLE);
+  }
+
+  private synchronized void setEndpointState(String endpointId, EndpointState state) {
+    Preconditions.checkNotNull(state);
+    Endpoint endpoint = endpointsMap.get(endpointId);
+    if (endpoint == null) {
+      return;
+    }
+    // If we allow some recovery time.
+    if (EndpointState.UNAVAILABLE.equals(state) && recoveryEnabled) {
+      endpoint.setState(EndpointState.RECOVERING);
+      ScheduledFuture<?> future =
+          executor.schedule(
+              () -> setEndpointStateInternal(endpointId, EndpointState.UNAVAILABLE),
+              recoveryTimeout.toMillis(),
+              MILLISECONDS);
+      endpoint.setChangeStateFuture(future);
+      return;
+    }
+    endpoint.resetStateChangeFuture();
+    endpoint.setState(state);
+    maybeFallback();
+  }
+
+  /**
+   * Provide an updated list of endpoints to MultiEndpoint.
+   *
+   * <p>MultiEndpoint will preserve current endpoints' state and update their priority according to
+   * their new positions.
+   */
+  public synchronized void setEndpoints(List<String> endpoints) {
+    Preconditions.checkNotNull(endpoints);
+    Preconditions.checkArgument(!endpoints.isEmpty(), "Endpoints list must not be empty.");
+
+    // Remove obsolete endpoints.
+    endpointsMap.keySet().retainAll(endpoints);
+
+    // Add new endpoints and update priority.
+    int priority = 0;
+    for (String endpointId : endpoints) {
+      Endpoint existingEndpoint = endpointsMap.get(endpointId);
+      if (existingEndpoint != null) {
+        existingEndpoint.setPriority(priority++);
+        continue;
+      }
+      EndpointState newState =
+          recoveryEnabled ? EndpointState.RECOVERING : EndpointState.UNAVAILABLE;
+      Endpoint newEndpoint = new Endpoint(endpointId, newState, priority++);
+      if (recoveryEnabled) {
+        ScheduledFuture<?> future =
+            executor.schedule(
+                () -> setEndpointStateInternal(endpointId, EndpointState.UNAVAILABLE),
+                recoveryTimeout.toMillis(),
+                MILLISECONDS);
+        newEndpoint.setChangeStateFuture(future);
+      }
+      endpointsMap.put(endpointId, newEndpoint);
+    }
+
+    maybeFallback();
+  }
+
+  private synchronized void maybeFallback() {
+    Optional<Endpoint> topEndpoint =
+        endpointsMap.values().stream()
+            .filter((c) -> c.getState().equals(EndpointState.AVAILABLE))
+            .min(comparingInt(Endpoint::getPriority));
+
+    Endpoint current = endpointsMap.get(currentId);
+    if (current != null && current.getState().equals(EndpointState.RECOVERING)) {
+      // Keep recovering endpoint as current unless a higher priority endpoint became available.
+      if (!topEndpoint.isPresent() || topEndpoint.get().getPriority() >= current.getPriority()) {
+        return;
+      }
+    }
+
+    if (!topEndpoint.isPresent() && current == null) {
+      topEndpoint = endpointsMap.values().stream().min(comparingInt(Endpoint::getPriority));
+    }
+
+    topEndpoint.ifPresent(endpoint -> currentId = endpoint.getId());
+  }
+}

--- a/grpc-gcp/src/test/java/com/google/cloud/grpc/multiendpoint/MultiEndpointTest.java
+++ b/grpc-gcp/src/test/java/com/google/cloud/grpc/multiendpoint/MultiEndpointTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.grpc.multiendpoint;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.client.util.Sleeper;
+import com.google.common.collect.ImmutableList;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for MultiEndpoint.
+ */
+@RunWith(JUnit4.class)
+public final class MultiEndpointTest {
+  private final List<String> threeEndpoints =
+      new ArrayList<>(ImmutableList.of("first", "second", "third"));
+
+  private final List<String> fourEndpoints =
+      new ArrayList<>(ImmutableList.of("four", "first", "third", "second"));
+
+  private static final long RECOVERY_MS = 1000;
+
+  @Rule
+  public ExpectedException expectedEx = ExpectedException.none();
+
+  private MultiEndpoint initPlain(List<String> endpoints) {
+    return new MultiEndpoint.Builder(endpoints).build();
+  }
+
+  private MultiEndpoint initWithRecovery(List<String> endpoints, long recoveryTimeOut) {
+    return new MultiEndpoint.Builder(endpoints)
+        .withRecoveryTimeout(Duration.ofMillis(recoveryTimeOut))
+        .build();
+  }
+
+  @Test
+  public void initPlain_raisesErrorWhenEmptyEndpoints() {
+    expectedEx.expect(IllegalArgumentException.class);
+    expectedEx.expectMessage("Endpoints list must not be empty.");
+    initPlain(ImmutableList.of());
+  }
+
+  @Test
+  public void initWithRecovery_raisesErrorWhenEmptyEndpoints() {
+    expectedEx.expect(IllegalArgumentException.class);
+    expectedEx.expectMessage("Endpoints list must not be empty.");
+    initWithRecovery(ImmutableList.of(), RECOVERY_MS);
+  }
+
+  @Test
+  public void getCurrent_returnsTopPriorityAvailableEndpointWithoutRecovery() {
+    MultiEndpoint multiEndpoint = initPlain(threeEndpoints);
+
+    // Returns first after creation.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(0));
+
+    // Second becomes available.
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(1), true);
+
+    // Second is the current as the only available.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(1));
+
+    // Third becomes available.
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(2), true);
+
+    // Second is still the current because it has higher priority.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(1));
+
+    // First becomes available.
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(0), true);
+
+    // First becomes the current because it has higher priority.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(0));
+
+    // Second becomes unavailable.
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(1), false);
+
+    // Second becoming unavailable should not affect the current first.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(0));
+
+    // First becomes unavailable.
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(0), false);
+
+    // Third becomes the current as the only remaining available.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(2));
+
+    // Third becomes unavailable.
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(2), false);
+
+    // After all endpoints became unavailable the multiEndpoint sticks to the last used endpoint.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(2));
+  }
+
+  @Test
+  public void getCurrent_returnsTopPriorityAvailableEndpointWithRecovery()
+      throws InterruptedException {
+    MultiEndpoint multiEndpoint = initWithRecovery(threeEndpoints, RECOVERY_MS);
+
+    // Returns first after creation.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(0));
+
+    // Second becomes available.
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(1), true);
+
+    // First is still the current to allow it to become available within recovery timeout.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(0));
+
+    // After recovery timeout has passed.
+    Sleeper.DEFAULT.sleep(RECOVERY_MS + 100);
+
+    // Second becomes current as an available endpoint with top priority.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(1));
+
+    // Third becomes available.
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(2), true);
+
+    // Second is still the current because it has higher priority.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(1));
+
+    // Second becomes unavailable.
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(1), false);
+
+    // Second is still current, allowing upto recoveryTimeout to recover.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(1));
+
+    // Halfway through recovery timeout the second recovers.
+    Sleeper.DEFAULT.sleep(RECOVERY_MS / 2);
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(1), true);
+
+    // Second is the current.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(1));
+
+    // After the initial recovery timeout, the second is still current.
+    Sleeper.DEFAULT.sleep(RECOVERY_MS / 2 + 100);
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(1));
+
+    // Second becomes unavailable.
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(1), false);
+
+    // After recovery timeout has passed.
+    Sleeper.DEFAULT.sleep(RECOVERY_MS + 100);
+
+    // Changes to an available endpoint -- third.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(2));
+
+    // First becomes available.
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(0), true);
+
+    // First becomes current immediately.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(0));
+
+    // First becomes unavailable.
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(0), false);
+
+    // First is still current, allowing upto recoveryTimeout to recover.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(0));
+
+    // After recovery timeout has passed.
+    Sleeper.DEFAULT.sleep(RECOVERY_MS + 100);
+
+    // Changes to an available endpoint -- third.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(2));
+
+    // Third becomes unavailable
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(2), false);
+
+    // Third is still current, allowing upto recoveryTimeout to recover.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(2));
+
+    // Halfway through recovery timeout the second becomes available.
+    // Sleeper.defaultSleeper().sleep(Duration.ofMillis(RECOVERY_MS - 100));
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(1), true);
+
+    // Second becomes current immediately.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(1));
+
+    // Second becomes unavailable.
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(1), false);
+
+    // Second is still current, allowing upto recoveryTimeout to recover.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(1));
+
+    // After recovery timeout has passed.
+    Sleeper.DEFAULT.sleep(RECOVERY_MS + 100);
+
+    // After all endpoints became unavailable the multiEndpoint sticks to the last used endpoint.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(threeEndpoints.get(1));
+  }
+
+  @Test
+  public void setEndpoints_raisesErrorWhenEmptyEndpoints() {
+    MultiEndpoint multiEndpoint = initPlain(threeEndpoints);
+    expectedEx.expect(IllegalArgumentException.class);
+    multiEndpoint.setEndpoints(ImmutableList.of());
+  }
+
+  @Test
+  public void setEndpoints_updatesEndpoints() {
+    MultiEndpoint multiEndpoint = initPlain(threeEndpoints);
+    multiEndpoint.setEndpoints(fourEndpoints);
+
+    // "first" which is now under index 1 still current because no other available.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(fourEndpoints.get(1));
+  }
+
+  @Test
+  public void setEndpoints_updatesEndpointsWithRecovery() {
+    MultiEndpoint multiEndpoint = initWithRecovery(threeEndpoints, RECOVERY_MS);
+    multiEndpoint.setEndpoints(fourEndpoints);
+
+    // "first" which is now under index 1 still current because no other available.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(fourEndpoints.get(1));
+  }
+
+  @Test
+  public void setEndpoints_updatesEndpointsPreservingStates() {
+    MultiEndpoint multiEndpoint = initPlain(threeEndpoints);
+
+    // Second is available.
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(1), true);
+    multiEndpoint.setEndpoints(fourEndpoints);
+
+    // "second" which is now under index 3 still must remain available.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(fourEndpoints.get(3));
+  }
+
+  @Test
+  public void setEndpoints_updatesEndpointsPreservingStatesWithRecovery()
+      throws InterruptedException {
+    MultiEndpoint multiEndpoint = initWithRecovery(threeEndpoints, RECOVERY_MS);
+
+    // After recovery timeout has passed.
+    Sleeper.DEFAULT.sleep(RECOVERY_MS + 100);
+
+    // Second is available.
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(1), true);
+    multiEndpoint.setEndpoints(fourEndpoints);
+
+    // "second" which is now under index 3 still must remain available.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(fourEndpoints.get(3));
+  }
+
+  @Test
+  public void setEndpoints_updatesEndpointsSwitchToTopPriorityAvailable() {
+    MultiEndpoint multiEndpoint = initPlain(threeEndpoints);
+
+    // Second and third is available.
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(1), true);
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(2), true);
+
+    multiEndpoint.setEndpoints(fourEndpoints);
+
+    // "third" which is now under index 2 must become current, because "second" has lower priority.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(fourEndpoints.get(2));
+  }
+
+  @Test
+  public void setEndpoints_updatesEndpointsSwitchToTopPriorityAvailableWithRecovery()
+      throws InterruptedException {
+    MultiEndpoint multiEndpoint = initWithRecovery(threeEndpoints, RECOVERY_MS);
+
+    // After recovery timeout has passed.
+    Sleeper.DEFAULT.sleep(RECOVERY_MS + 100);
+
+    // Second and third is available.
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(1), true);
+    multiEndpoint.setEndpointAvailable(threeEndpoints.get(2), true);
+
+    multiEndpoint.setEndpoints(fourEndpoints);
+
+    // "third" which is now under index 2 must become current, because "second" has lower priority.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(fourEndpoints.get(2));
+  }
+
+  @Test
+  public void setEndpoints_updatesEndpointsRemovesOnlyActiveEndpoint() {
+    List<String> extraEndpoints = new ArrayList<>(threeEndpoints);
+    extraEndpoints.add("extra");
+    MultiEndpoint multiEndpoint = initPlain(extraEndpoints);
+
+    // Extra is available.
+    multiEndpoint.setEndpointAvailable("extra", true);
+
+    // Extra is removed.
+    multiEndpoint.setEndpoints(fourEndpoints);
+
+    // "four" which is under index 0 must become current, because no endpoints available.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(fourEndpoints.get(0));
+  }
+
+  @Test
+  public void setEndpoints_updatesEndpointsRemovesOnlyActiveEndpointWithRecovery()
+      throws InterruptedException {
+    List<String> extraEndpoints = new ArrayList<>(threeEndpoints);
+    extraEndpoints.add("extra");
+    MultiEndpoint multiEndpoint = initWithRecovery(extraEndpoints, RECOVERY_MS);
+
+    // After recovery timeout has passed.
+    Sleeper.DEFAULT.sleep(RECOVERY_MS + 100);
+
+    // Extra is available.
+    multiEndpoint.setEndpointAvailable("extra", true);
+
+    // Extra is removed.
+    multiEndpoint.setEndpoints(fourEndpoints);
+
+    // "four" which is under index 0 must become current, because no endpoints available.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(fourEndpoints.get(0));
+  }
+
+  @Test
+  public void setEndpoints_recoveringEndpointGetsRemoved() throws InterruptedException {
+    List<String> extraEndpoints = new ArrayList<>(threeEndpoints);
+    extraEndpoints.add("extra");
+    MultiEndpoint multiEndpoint = initWithRecovery(extraEndpoints, RECOVERY_MS);
+
+    // After recovery timeout has passed.
+    Sleeper.DEFAULT.sleep(RECOVERY_MS + 100);
+
+    // Extra is available.
+    multiEndpoint.setEndpointAvailable("extra", true);
+
+    // Extra is recovering.
+    multiEndpoint.setEndpointAvailable("extra", false);
+
+    // Extra is removed.
+    multiEndpoint.setEndpoints(fourEndpoints);
+
+    // "four" which is under index 0 must become current, because no endpoints available.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(fourEndpoints.get(0));
+
+    // After recovery timeout has passed.
+    Sleeper.DEFAULT.sleep(RECOVERY_MS + 100);
+
+    // "four" is still current.
+    assertThat(multiEndpoint.getCurrentId()).isEqualTo(fourEndpoints.get(0));
+  }
+}


### PR DESCRIPTION
The purpose of GcpMultiEndpointChannel is twofold:

1. Fallback to an alternative endpoint (host:port) of a gRPC service when the original endpoint is completely unavailable.
2. Be able to route an RPC call to a specific group of endpoints.

A group of endpoints is called a MultiEndpoint and is essentially a list of endpoints where priority is defined by the position in the list with the first endpoint having top priority. A MultiEndpoint tracks endpoints' availability. When a MultiEndpoint is picked for an RPC call, it picks the top priority endpoint that is currently available. More information on the MultiEndpoint class.

GcpMultiEndpointChannel can have one or more MultiEndpoint identified by its name -- arbitrary string provided in the GcpMultiEndpointOptions when configuring MultiEndpoints. This name can be used to route an RPC call to this MultiEndpoint by setting the ME_KEY key value of the RPC CallOptions.

GcpMultiEndpointChannel receives a list of GcpMultiEndpointOptions for initial configuration. An updated configuration can be provided at any time later using setMultiEndpoints(List). The first item in the GcpMultiEndpointOptions list defines the default MultiEndpoint that will be used when no MultiEndpoint name is provided with an RPC call.

Example configuration:

- MultiEndpoint named "default" with endpoints:

1. service.example.com:443
2. service-fallback.example.com:443

- MultiEndpoint named "read" with endpoints:

1. ro-service.example.com:443
2. service-fallback.example.com:443
3. service.example.com:443

Let's assume we have a service with read and write operations and the following backends:

- service.example.com -- the main set of backends supporting all operations
- service-fallback.example.com -- read-write replica supporting all operations
- ro-service.example.com -- read-only replica supporting only read operations

With the configuration above GcpMultiEndpointChannel will use the "default" MultiEndpoint by default. It means that RPC calls by default will use the main endpoint and if it is not available then the read-write replica.

To offload some read calls to the read-only replica we can specify "read" MultiEndpoint in the CallOptions. Then these calls will use the read-only replica endpoint and if it is not available then the read-write replica and if it is also not available then the main endpoint.

GcpMultiEndpointChannel creates a GcpManagedChannel channel pool for every unique endpoint. For the example above three channel pools will be created.