### PR TITLE
feat: add gcs api services client to benchmarks

### DIFF
--- a/end2end-test-examples/gcs/README.md
+++ b/end2end-test-examples/gcs/README.md
@@ -1,5 +1,5 @@
 ## Args
-`--client`: Type of client to use, among `grpc`, `yoshi`, `gcsio-grpc`, `gcsio-json`
+`--client`: Type of client to use, among `grpc`, `yoshi`, `gcsio-grpc`, `gcsio-json`, `api-services-json`
 
 `--calls`: Number of calls to execute
 

--- a/end2end-test-examples/gcs/build.gradle
+++ b/end2end-test-examples/gcs/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     compile "com.google.api.grpc:proto-google-common-protos:latest.release"
     compile "com.google.auth:google-auth-library-oauth2-http:latest.release"
     compile "com.google.cloud:google-cloud-storage:latest.release"
+    compile "com.google.apis:google-api-services-storage:latest.release"
     compile "com.google.cloud.bigdataoss:gcsio:${gcsioVersion}"
     compile "com.google.cloud.bigdataoss:bigdataoss-parent:${gcsioVersion}"
     compile "com.google.guava:guava:31.1-jre"

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/Args.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/Args.java
@@ -15,6 +15,7 @@ public class Args {
   public static final String CLIENT_GCSIO_JSON = "gcsio-json";
   public static final String CLIENT_JAVA_GRPC = "java-grpc";
   public static final String CLIENT_JAVA_JSON = "java-json";
+  public static final String CLIENT_API_SERVICES_JSON = "api-services-json";
 
   public static final String DEFAULT_HOST = "storage.googleapis.com";
   private static final int PORT = 443;

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/JavaApiServicesClient.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/JavaApiServicesClient.java
@@ -1,0 +1,175 @@
+package io.grpc.gcs;
+
+import static io.grpc.gcs.Args.METHOD_RANDOM;
+import static io.grpc.gcs.Args.METHOD_READ;
+import static io.grpc.gcs.Args.METHOD_WRITE;
+
+import com.google.api.client.googleapis.media.MediaHttpDownloader;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.InputStreamContent;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.model.StorageObject;
+import com.google.cloud.http.HttpTransportOptions;
+import com.google.cloud.storage.StorageOptions;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+public class JavaApiServicesClient {
+  private static final Logger logger = Logger.getLogger(JavaClient.class.getName());
+
+  private Args args;
+  private ObjectResolver objectResolver;
+  private Storage client;
+
+  public JavaApiServicesClient(Args args) {
+    this.args = args;
+    this.objectResolver = new ObjectResolver(args.obj, args.objFormat, args.objStart, args.objStop);
+    /* Use StorageOptions library defaults */
+    StorageOptions storageOptions = StorageOptions.getDefaultInstance();
+    HttpTransportOptions transportOptions = (HttpTransportOptions)storageOptions.getTransportOptions();
+    HttpRequestInitializer initializer = transportOptions.getHttpRequestInitializer(storageOptions);
+    HttpTransport transport = transportOptions.getHttpTransportFactory().create();
+    this.client = new Storage.Builder(transport, new JacksonFactory(), initializer).build();
+  }
+
+  public void startCalls(ResultTable results) throws InterruptedException, IOException {
+    if (args.threads == 0) {
+      switch (args.method) {
+        case METHOD_READ:
+          makeMediaRequest(results, /*threadId=*/ 1);
+          break;
+        case METHOD_RANDOM:
+          makeRandomMediaRequest(results, /*threadId=*/ 1);
+          break;
+        case METHOD_WRITE:
+          makeInsertRequest(results, /*threadId=*/ 1);
+          break;
+        default:
+          logger.warning("Please provide valid methods with --method");
+      }
+    } else {
+      ThreadPoolExecutor threadPoolExecutor =
+          (ThreadPoolExecutor) Executors.newFixedThreadPool(args.threads);
+      switch (args.method) {
+        case METHOD_READ:
+          for (int i = 0; i < args.threads; i++) {
+            int finalI = i;
+            Runnable task = () -> makeMediaRequest(results, finalI + 1);
+            threadPoolExecutor.execute(task);
+          }
+          break;
+        case METHOD_RANDOM:
+          for (int i = 0; i < args.threads; i++) {
+            int finalI = i;
+            Runnable task =
+                () -> {
+                  try {
+                    makeRandomMediaRequest(results, finalI + 1);
+                  } catch (IOException e) {
+                    e.printStackTrace();
+                  }
+                };
+            threadPoolExecutor.execute(task);
+          }
+          break;
+        case METHOD_WRITE:
+          for (int i = 0; i < args.threads; i++) {
+            int finalI = i;
+            Runnable task = () -> makeInsertRequest(results, finalI + 1);
+            threadPoolExecutor.execute(task);
+          }
+          break;
+        default:
+          logger.warning("Please provide valid methods with --method");
+      }
+      threadPoolExecutor.shutdown();
+      if (!threadPoolExecutor.awaitTermination(30, TimeUnit.MINUTES)) {
+        threadPoolExecutor.shutdownNow();
+      }
+    }
+  }
+
+  public void makeMediaRequest(ResultTable results, int threadId) {
+    for (int i = 0; i < args.calls; i++) {
+      String object = objectResolver.Resolve(threadId, i);
+      long start = System.currentTimeMillis();
+      byte[] content = new byte[0];
+      try {
+        Storage.Objects.Get req = client
+                .objects()
+                .get(args.bkt, object);
+        req.setReturnRawInputStream(true);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        req.executeMedia().download(output);
+        content = output.toByteArray();
+      } catch (IOException ioException) {
+        System.err.println(ioException);
+      }
+      long dur = System.currentTimeMillis() - start;
+      results.reportResult(args.bkt, object, content.length, dur);
+    }
+  }
+
+  public void makeRandomMediaRequest(ResultTable results, int threadId) throws IOException {
+    Random r = new Random();
+    String object = objectResolver.Resolve(threadId, /*objectId=*/ 0);
+    for (int i = 0; i < args.calls; i++) {
+      long offset = (long) r.nextInt(args.size - args.buffSize) * 1024;
+      long start = System.currentTimeMillis();
+      ByteBuffer buff = ByteBuffer.allocate(args.buffSize * 1024);
+      try {
+        Storage.Objects.Get req = client.objects().get(args.bkt, object);
+        if(offset > 0) {
+          req.getRequestHeaders().setRange(String.format("bytes=%d-", offset));
+        }
+        req.setReturnRawInputStream(false);
+        MediaHttpDownloader mediaHttpDownloader = req.getMediaHttpDownloader();
+        mediaHttpDownloader.setDirectDownloadEnabled(true);
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        req.executeMedia().download(byteArrayOutputStream);
+        buff.put(byteArrayOutputStream.toByteArray());
+      } catch (IOException ioException) {
+        System.err.println(ioException);
+      }
+      long dur = System.currentTimeMillis() - start;
+      if (buff.remaining() > 0) {
+        logger.warning("Got remaining bytes: " + buff.remaining());
+      }
+      buff.clear();
+      results.reportResult(args.bkt, object, args.buffSize * 1024, dur);
+    }
+  }
+
+  public void makeInsertRequest(ResultTable results, int threadId) {
+    int totalBytes = args.size * 1024;
+    byte[] data = new byte[totalBytes];
+    for (int i = 0; i < args.calls; i++) {
+      String object = objectResolver.Resolve(threadId, i);
+      long start = System.currentTimeMillis();
+      try {
+        StorageObject storageObject = new StorageObject();
+        storageObject.setBucket(args.bkt).setName(object);
+        Storage.Objects.Insert insert =
+                client.objects().insert(
+                        args.bkt, storageObject,
+                        new InputStreamContent("application/octet-stream", new ByteArrayInputStream(data)));
+        insert.getMediaHttpUploader().setDirectUploadEnabled(true);
+        insert.execute();
+      } catch (IOException ioException) {
+        System.err.println(ioException);
+      }
+      long dur = System.currentTimeMillis() - start;
+      results.reportResult(args.bkt, object, totalBytes, dur);
+    }
+  }
+}

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/TestMain.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/TestMain.java
@@ -61,6 +61,7 @@ public class TestMain {
         results.start();
         javaApiServicesClient.startCalls(results);
         results.stop();
+        break;
       default:
         logger.warning("Please provide --client");
     }

--- a/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/TestMain.java
+++ b/end2end-test-examples/gcs/src/main/java/io/grpc/gcs/TestMain.java
@@ -5,6 +5,7 @@ import static io.grpc.gcs.Args.CLIENT_GCSIO_GRPC;
 import static io.grpc.gcs.Args.CLIENT_GCSIO_JSON;
 import static io.grpc.gcs.Args.CLIENT_JAVA_GRPC;
 import static io.grpc.gcs.Args.CLIENT_JAVA_JSON;
+import static io.grpc.gcs.Args.CLIENT_API_SERVICES_JSON;
 
 import java.io.FileInputStream;
 import java.security.Security;
@@ -55,6 +56,11 @@ public class TestMain {
         javaClient.startCalls(results);
         results.stop();
         break;
+      case CLIENT_API_SERVICES_JSON:
+        JavaApiServicesClient javaApiServicesClient = new JavaApiServicesClient(a);
+        results.start();
+        javaApiServicesClient.startCalls(results);
+        results.stop();
       default:
         logger.warning("Please provide --client");
     }


### PR DESCRIPTION
Add GCS API Services client to existing benchmarks; Tested running command:

```
 ./gradlew run --args="--client=api-services-json --bkt=anima-frank --obj=1kb --calls=100 --method=read"
```

```
 ./gradlew run --args="--client=api-services-json --bkt=anima-frank --obj=1kb --calls=1 --method=write"
```

However, it's not clear how this command gets added to the test runner. Thanks for your review.
@BenWhitehead I copied implementation from the java-storage client; but you may have more thoughts on the Api Services client usage patterns.

cc: @danielduhh