### PR TITLE
Test case + bugfix for MultiEndpoint

### DIFF
--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpMultiEndpointChannel.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpMultiEndpointChannel.java
@@ -253,6 +253,7 @@ public class GcpMultiEndpointChannel extends ManagedChannel {
       }
     });
 
+    final Set<String> existingPools = new HashSet<>(pools.keySet());
     currentEndpoints.clear();
     // TODO: Support the same endpoint in different MultiEndpoint to use different channel
     //       credentials.
@@ -293,9 +294,12 @@ public class GcpMultiEndpointChannel extends ManagedChannel {
           new EndpointStateMonitor(channel, e);
           return channel;
         });
-        // Communicate current state to MultiEndpoints.
-        checkPoolState(pools.get(endpoint), endpoint);
       });
+    });
+    existingPools.retainAll(currentEndpoints);
+    existingPools.forEach(e -> {
+      // Communicate current state to MultiEndpoints.
+      checkPoolState(pools.get(e), e);
     });
     defaultMultiEndpoint = multiEndpoints.get(meOptions.get(0).getName());
 

--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/multiendpoint/MultiEndpoint.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/multiendpoint/MultiEndpoint.java
@@ -206,9 +206,7 @@ public final class MultiEndpoint {
       topEndpoint = endpointsMap.values().stream().min(comparingInt(Endpoint::getPriority));
     }
 
-    if (topEndpoint.isPresent()) {
-      updateCurrentEndpoint(current, topEndpoint.get().getId());
-    }
+    topEndpoint.ifPresent(endpoint -> updateCurrentEndpoint(current, endpoint.getId()));
   }
 
   private synchronized void updateCurrentEndpoint(Endpoint current, String newCurrentId) {
@@ -224,6 +222,10 @@ public final class MultiEndpoint {
     }
 
     switchTo = newCurrentId;
+    if (switchTo.equals(currentId)) {
+      return;
+    }
+
     if (scheduledSwitch == null || scheduledSwitch.isDone()) {
       scheduledSwitch =
           executor.schedule(this::switchCurrentEndpoint, switchingDelay.toMillis(), MILLISECONDS);


### PR DESCRIPTION
- Prevent preemptive switching in MultiEndpoint (+test).
- Reduce state checks for repeating endpoints.
- Add add/remove endpoint test case for switching delay.