### PR TITLE
feat: Dynamic channel pool scaling

### DIFF
--- a/grpc-gcp/build.gradle
+++ b/grpc-gcp/build.gradle
@@ -1,10 +1,9 @@
 plugins {
     id 'java'
-    id 'maven'
     id 'maven-publish'
     id 'signing'
-    id 'com.google.protobuf' version '0.8.10'
-    id 'com.github.sherter.google-java-format' version '0.8'
+    id 'com.google.protobuf' version '0.9.4'
+    id 'com.github.sherter.google-java-format' version '0.9'
     id 'io.codearte.nexus-staging' version '0.8.0'
 }
 
@@ -162,4 +161,9 @@ signing {
         }
         sign publishing.publications.maven
     }
+}
+
+googleJavaFormat {
+    // Latest GJF that supports Java 8.
+    toolVersion = "1.7"
 }

--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannel.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannel.java
@@ -52,11 +52,15 @@ import io.opencensus.metrics.MetricRegistry;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.LongSummaryStatistics;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
@@ -69,12 +73,16 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /** A channel management factory that implements grpc.Channel APIs. */
 public class GcpManagedChannel extends ManagedChannel {
   private static final Logger logger = Logger.getLogger(GcpManagedChannel.class.getName());
   static final AtomicInteger channelPoolIndex = new AtomicInteger();
+
+  // Counter for tracking channel ids.
+  final AtomicInteger nextChannelId = new AtomicInteger();
   static final int DEFAULT_MAX_CHANNEL = 10;
   static final int DEFAULT_MAX_STREAM = 100;
   public static final Context.Key<Boolean> DISABLE_AFFINITY_CTX_KEY =
@@ -95,6 +103,11 @@ public class GcpManagedChannel extends ManagedChannel {
   private final int unresponsiveDropCount;
   private int maxSize = DEFAULT_MAX_CHANNEL;
   private int minSize = 0;
+  private int initSize = 0;
+  private int minRpcPerChannel = 0;
+  private int maxRpcPerChannel = 0;
+  private Duration scaleDownInterval = Duration.ZERO;
+  private boolean isDynamicScalingEnabled = false;
   private int maxConcurrentStreamsLowWatermark = DEFAULT_MAX_STREAM;
   private Duration affinityKeyLifetime = Duration.ZERO;
 
@@ -108,7 +121,11 @@ public class GcpManagedChannel extends ManagedChannel {
   // Map from a broken channel id to the remapped affinity keys (key => ready channel id).
   private final Map<Integer, Map<String, Integer>> fallbackMap = new ConcurrentHashMap<>();
 
+  // The channel pool.
   @VisibleForTesting final List<ChannelRef> channelRefs = new CopyOnWriteArrayList<>();
+  // A set of channels that we removed from the pool and wait for their RPCs to be completed before
+  // we can shut them down.
+  final Set<ChannelRef> removedChannelRefs = new HashSet<>();
 
   private final ExecutorService stateNotificationExecutor =
       Executors.newCachedThreadPool(
@@ -125,6 +142,11 @@ public class GcpManagedChannel extends ManagedChannel {
       new ArrayList<>(
           Collections.singletonList(
               LabelKey.create(GcpMetricsConstants.RESULT_LABEL, GcpMetricsConstants.RESULT_DESC)));
+  private final List<LabelKey> labelKeysWithDirection =
+      new ArrayList<>(
+          Collections.singletonList(
+              LabelKey.create(
+                  GcpMetricsConstants.DIRECTION_LABEL, GcpMetricsConstants.DIRECTION_LABEL_DESC)));
   private final List<LabelValue> labelValues = new ArrayList<>();
   private final List<LabelValue> labelValuesSuccess =
       new ArrayList<>(
@@ -132,15 +154,23 @@ public class GcpManagedChannel extends ManagedChannel {
   private final List<LabelValue> labelValuesError =
       new ArrayList<>(
           Collections.singletonList(LabelValue.create(GcpMetricsConstants.RESULT_ERROR)));
+  private final List<LabelValue> labelValuesUp =
+      new ArrayList<>(
+          Collections.singletonList(LabelValue.create(GcpMetricsConstants.DIRECTION_UP)));
+  private final List<LabelValue> labelValuesDown =
+      new ArrayList<>(
+          Collections.singletonList(LabelValue.create(GcpMetricsConstants.DIRECTION_DOWN)));
   private String metricPrefix;
   private final String metricPoolIndex =
       String.format("pool-%d", channelPoolIndex.incrementAndGet());
   private final Map<String, Long> cumulativeMetricValues = new ConcurrentHashMap<>();
-  private ScheduledExecutorService logMetricService;
-  private ScheduledExecutorService keysCleanupService;
+  private final ScheduledExecutorService backgroundService =
+      Executors.newSingleThreadScheduledExecutor();
 
   // Metrics counters.
   private final AtomicInteger readyChannels = new AtomicInteger();
+  private int minChannels = 0;
+  private int maxChannels = 0;
   private int minReadyChannels = 0;
   private int maxReadyChannels = 0;
   private final AtomicLong numChannelConnect = new AtomicLong();
@@ -154,6 +184,7 @@ public class GcpManagedChannel extends ManagedChannel {
   private int maxActiveStreams = 0;
   private int minTotalActiveStreams = 0;
   private int maxTotalActiveStreams = 0;
+  private int maxTotalActiveStreamsForScaleDown = 0;
   private long minOkCalls = 0;
   private long maxOkCalls = 0;
   private final AtomicLong totalOkCalls = new AtomicLong();
@@ -174,6 +205,8 @@ public class GcpManagedChannel extends ManagedChannel {
   private long maxUnresponsiveMs = 0;
   private long minUnresponsiveDrops = 0;
   private long maxUnresponsiveDrops = 0;
+  private long scaleUpCount = 0;
+  private long scaleDownCount = 0;
 
   /**
    * Constructor for GcpManagedChannel.
@@ -206,11 +239,12 @@ public class GcpManagedChannel extends ManagedChannel {
       unresponsiveMs = 0;
       unresponsiveDropCount = 0;
     }
-    initMinChannels();
+    initChannels();
     GcpChannelPoolOptions channelPoolOptions = options.getChannelPoolOptions();
     if (channelPoolOptions != null) {
       affinityKeyLifetime = channelPoolOptions.getAffinityKeyLifetime();
       initCleanupTask(channelPoolOptions.getCleanupInterval());
+      initScaleDownChecker(channelPoolOptions.getScaleDownInterval());
     }
   }
 
@@ -248,6 +282,75 @@ public class GcpManagedChannel extends ManagedChannel {
         });
   }
 
+  private synchronized void checkScaleDown() {
+    if (!isDynamicScalingEnabled) {
+      return;
+    }
+
+    // Number of channels to support maximum seen (since last check) concurrent streams
+    // with lowest desired utilization (minRpcPerChannel).
+    int desiredSize =
+        maxTotalActiveStreamsForScaleDown / minRpcPerChannel
+            + ((maxTotalActiveStreamsForScaleDown % minRpcPerChannel == 0) ? 0 : 1);
+
+    // Reset maxTotalActiveStreamsForScaleDown.
+    maxTotalActiveStreamsForScaleDown = totalActiveStreams.get();
+
+    int scaleDownTo = Math.max(minSize, desiredSize);
+    // Remove those extra channels that are the oldest.
+    removeOldestChannels(channelRefs.size() - scaleDownTo);
+
+    // Shutdown removed channels where all RPCs are completed.
+    List<ChannelRef> completedChRefs =
+        removedChannelRefs.stream()
+            .filter(chRef -> (chRef.getActiveStreamsCount() == 0))
+            .collect(Collectors.toList());
+    removedChannelRefs.removeAll(completedChRefs);
+    for (ChannelRef channelRef : completedChRefs) {
+      channelRef.getChannel().shutdown();
+      // Remove channel from broken channels map.
+      fallbackMap.remove(channelRef.getId());
+    }
+  }
+
+  private void removeOldestChannels(int num) {
+    if (num <= 0) {
+      return;
+    }
+
+    // Select longest connected channels (or disconnected channels).
+    final List<ChannelRef> channelsToRemove =
+        channelRefs.stream()
+            .sorted(Comparator.comparing(ChannelRef::getConnectedSinceNanos))
+            .limit(num)
+            .collect(Collectors.toList());
+
+    // Remove from active channels.
+    channelRefs.removeAll(channelsToRemove);
+
+    for (ChannelRef channelRef : channelsToRemove) {
+      channelRef.resetAffinityCount();
+      if (channelRef.getState() == ConnectivityState.READY) {
+        decReadyChannels(false);
+      }
+    }
+
+    // Remove affinity keys mapping for the channels.
+    affinityKeyToChannelRef
+        .keySet()
+        .removeIf(key -> channelsToRemove.contains(affinityKeyToChannelRef.get(key)));
+
+    // Keep them aside to wait for all RPCs to complete.
+    removedChannelRefs.addAll(channelsToRemove);
+
+    // Track minimum number of channels for metrics.
+    minChannels = Math.min(minChannels, channelRefs.size());
+    scaleDownCount += channelsToRemove.size();
+
+    // Removing a channel may change channel pool state.
+    executeStateChangeCallbacks();
+  }
+
   private Supplier<String> log(Supplier<String> messageSupplier) {
     return () -> String.format("%s: %s", metricPoolIndex, messageSupplier.get());
   }
@@ -260,8 +363,8 @@ public class GcpManagedChannel extends ManagedChannel {
     return String.format("%s: %s", metricPoolIndex, String.format(format, args));
   }
 
-  private synchronized void initMinChannels() {
-    while (minSize - getNumberOfChannels() > 0) {
+  private synchronized void initChannels() {
+    while (Math.max(minSize, initSize) - getNumberOfChannels() > 0) {
       createNewChannel();
     }
   }
@@ -272,28 +375,41 @@ public class GcpManagedChannel extends ManagedChannel {
       maxSize = poolOptions.getMaxSize();
       minSize = poolOptions.getMinSize();
       maxConcurrentStreamsLowWatermark = poolOptions.getConcurrentStreamsLowWatermark();
+      initSize = poolOptions.getInitSize();
+      minRpcPerChannel = poolOptions.getMinRpcPerChannel();
+      maxRpcPerChannel = poolOptions.getMaxRpcPerChannel();
+      scaleDownInterval = poolOptions.getScaleDownInterval();
+      isDynamicScalingEnabled =
+          minRpcPerChannel > 0 && maxRpcPerChannel > 0 && !scaleDownInterval.isZero();
     }
     initMetrics();
   }
 
   private synchronized void initCleanupTask(Duration cleanupInterval) {
-    if (cleanupInterval.isZero() || keysCleanupService != null) {
+    if (cleanupInterval.isZero()) {
       return;
     }
-    keysCleanupService = Executors.newSingleThreadScheduledExecutor();
-    keysCleanupService.scheduleAtFixedRate(
+    backgroundService.scheduleAtFixedRate(
         this::cleanupAffinityKeys,
         cleanupInterval.toMillis(),
         cleanupInterval.toMillis(),
         MILLISECONDS);
   }
 
-  private synchronized void initLogMetrics() {
-    if (logMetricService != null) {
+  private synchronized void initScaleDownChecker(Duration scaleDownInterval) {
+    if (!isDynamicScalingEnabled || scaleDownInterval.isZero()) {
       return;
     }
-    logMetricService = Executors.newSingleThreadScheduledExecutor();
-    logMetricService.scheduleAtFixedRate(this::logMetrics, 60, 60, SECONDS);
+
+    backgroundService.scheduleAtFixedRate(
+        this::checkScaleDown,
+        scaleDownInterval.toMillis(),
+        scaleDownInterval.toMillis(),
+        MILLISECONDS);
+  }
+
+  private synchronized void initLogMetrics() {
+    backgroundService.scheduleAtFixedRate(this::logMetrics, 60, 60, SECONDS);
   }
 
   private void logMetricsOptions() {
@@ -309,6 +425,14 @@ public class GcpManagedChannel extends ManagedChannel {
             Joiner.on(", ")
                 .join(
                     channelRefs.stream().mapToInt(ChannelRef::getActiveStreamsCount).iterator())));
+    logger.fine(
+        log(
+            "Removed channels active streams counts: [%s]",
+            Joiner.on(", ")
+                .join(
+                    removedChannelRefs.stream()
+                        .mapToInt(ChannelRef::getActiveStreamsCount)
+                        .iterator())));
     logger.fine(
         log(
             "Affinity counts: [%s]",
@@ -334,18 +458,24 @@ public class GcpManagedChannel extends ManagedChannel {
     metricRegistry = metricsOptions.getMetricRegistry();
     labelKeys.addAll(metricsOptions.getLabelKeys());
     labelKeysWithResult.addAll(metricsOptions.getLabelKeys());
+    labelKeysWithDirection.addAll(metricsOptions.getLabelKeys());
     labelValues.addAll(metricsOptions.getLabelValues());
     labelValuesSuccess.addAll(metricsOptions.getLabelValues());
     labelValuesError.addAll(metricsOptions.getLabelValues());
+    labelValuesUp.addAll(metricsOptions.getLabelValues());
+    labelValuesDown.addAll(metricsOptions.getLabelValues());
 
     final LabelKey poolKey =
         LabelKey.create(GcpMetricsConstants.POOL_INDEX_LABEL, GcpMetricsConstants.POOL_INDEX_DESC);
     labelKeys.add(poolKey);
     labelKeysWithResult.add(poolKey);
+    labelKeysWithDirection.add(poolKey);
     final LabelValue poolIndex = LabelValue.create(metricPoolIndex);
     labelValues.add(poolIndex);
     labelValuesSuccess.add(poolIndex);
     labelValuesError.add(poolIndex);
+    labelValuesUp.add(poolIndex);
+    labelValuesDown.add(poolIndex);
 
     metricPrefix = metricsOptions.getNamePrefix();
 
@@ -362,6 +492,20 @@ public class GcpManagedChannel extends ManagedChannel {
         GcpMetricsConstants.COUNT,
         this,
         GcpManagedChannel::reportMaxReadyChannels);
+
+    createDerivedLongGaugeTimeSeries(
+        GcpMetricsConstants.METRIC_NUM_CHANNELS,
+        "The number of channels currently in the pool.",
+        GcpMetricsConstants.COUNT,
+        this,
+        GcpManagedChannel::reportNumChannels);
+
+    createDerivedLongGaugeTimeSeries(
+        GcpMetricsConstants.METRIC_MIN_CHANNELS,
+        "The minimum number of channels in the pool.",
+        GcpMetricsConstants.COUNT,
+        this,
+        GcpManagedChannel::reportMinChannels);
 
     createDerivedLongGaugeTimeSeries(
         GcpMetricsConstants.METRIC_MAX_CHANNELS,
@@ -527,6 +671,14 @@ public class GcpManagedChannel extends ManagedChannel {
         GcpMetricsConstants.MILLISECOND,
         this,
         GcpManagedChannel::reportMaxUnresponsiveDrops);
+
+    createDerivedLongCumulativeTimeSeriesWithDirection(
+        GcpMetricsConstants.METRIC_CHANNEL_POOL_SCALING,
+        "The number of channels channel pool scaled up or down.",
+        GcpMetricsConstants.COUNT,
+        this,
+        GcpManagedChannel::reportScaleUp,
+        GcpManagedChannel::reportScaleDown);
   }
 
   private void logGauge(String key, long value) {
@@ -549,8 +701,12 @@ public class GcpManagedChannel extends ManagedChannel {
     logChannelsStats();
     reportMinReadyChannels();
     reportMaxReadyChannels();
+    reportMinChannels();
     reportMaxChannels();
+    reportNumChannels();
     reportMaxAllowedChannels();
+    reportScaleUp();
+    reportScaleDown();
     reportNumChannelDisconnect();
     reportNumChannelConnect();
     reportMinReadinessTime();
@@ -614,6 +770,23 @@ public class GcpManagedChannel extends ManagedChannel {
     metric.createTimeSeries(labelValuesError, obj, funcErr);
   }
 
+  private <T> void createDerivedLongCumulativeTimeSeriesWithDirection(
+      String name,
+      String description,
+      String unit,
+      T obj,
+      ToLongFunction<T> funcUp,
+      ToLongFunction<T> funcDown) {
+    final DerivedLongCumulative metric =
+        metricRegistry.addDerivedLongCumulative(
+            metricPrefix + name, createMetricOptions(description, labelKeysWithDirection, unit));
+
+    metric.removeTimeSeries(labelValuesUp);
+    metric.createTimeSeries(labelValuesUp, obj, funcUp);
+    metric.removeTimeSeries(labelValuesDown);
+    metric.createTimeSeries(labelValuesDown, obj, funcDown);
+  }
+
   private <T> void createDerivedLongCumulativeTimeSeries(
       String name, String description, String unit, T obj, ToLongFunction<T> func) {
     final DerivedLongCumulative metric =
@@ -641,9 +814,22 @@ public class GcpManagedChannel extends ManagedChannel {
     metric.createTimeSeries(labelValuesError, obj, funcErr);
   }
 
-  // TODO: When introducing pool downscaling feature this method must be changed accordingly.
-  private long reportMaxChannels() {
+  private long reportNumChannels() {
     int value = getNumberOfChannels();
+    logGauge(GcpMetricsConstants.METRIC_NUM_CHANNELS, value);
+    return value;
+  }
+
+  private long reportMinChannels() {
+    int value = minChannels;
+    minChannels = getNumberOfChannels();
+    logGauge(GcpMetricsConstants.METRIC_MIN_CHANNELS, value);
+    return value;
+  }
+
+  private long reportMaxChannels() {
+    int value = maxChannels;
+    maxChannels = getNumberOfChannels();
     logGauge(GcpMetricsConstants.METRIC_MAX_CHANNELS, value);
     return value;
   }
@@ -779,8 +965,7 @@ public class GcpManagedChannel extends ManagedChannel {
   private LongSummaryStatistics calcStatsAndLog(String logLabel, ToLongFunction<ChannelRef> func) {
     StringBuilder str = new StringBuilder(logLabel + ": [");
     final LongSummaryStatistics stats =
-        channelRefs
-            .stream()
+        channelRefs.stream()
             .mapToLong(
                 ch -> {
                   long count = func.applyAsLong(ch);
@@ -886,16 +1071,32 @@ public class GcpManagedChannel extends ManagedChannel {
     return value;
   }
 
-  private void incReadyChannels() {
-    numChannelConnect.incrementAndGet();
+  private long reportScaleUp() {
+    long value = scaleUpCount;
+    logCumulative(GcpMetricsConstants.METRIC_CHANNEL_POOL_SCALING + "_up", value);
+    return value;
+  }
+
+  private long reportScaleDown() {
+    long value = scaleDownCount;
+    logCumulative(GcpMetricsConstants.METRIC_CHANNEL_POOL_SCALING + "_down", value);
+    return value;
+  }
+
+  private void incReadyChannels(boolean connected) {
+    if (connected) {
+      numChannelConnect.incrementAndGet();
+    }
     final int newReady = readyChannels.incrementAndGet();
     if (maxReadyChannels < newReady) {
       maxReadyChannels = newReady;
     }
   }
 
-  private void decReadyChannels() {
-    numChannelDisconnect.incrementAndGet();
+  private void decReadyChannels(boolean disconnected) {
+    if (disconnected) {
+      numChannelDisconnect.incrementAndGet();
+    }
     final int newReady = readyChannels.decrementAndGet();
     if (minReadyChannels > newReady) {
       minReadyChannels = newReady;
@@ -954,15 +1155,24 @@ public class GcpManagedChannel extends ManagedChannel {
    * route requests via another ready channel if the option is enabled.
    */
   private class ChannelStateMonitor implements Runnable {
-    private final int channelId;
+    private final ChannelRef channelRef;
     private final ManagedChannel channel;
     private ConnectivityState currentState;
     private long connectingStartNanos;
+    private long connectedSinceNanos;
 
-    private ChannelStateMonitor(ManagedChannel channel, int channelId) {
-      this.channelId = channelId;
+    private ChannelStateMonitor(ManagedChannel channel, ChannelRef channelRef) {
+      this.channelRef = channelRef;
       this.channel = channel;
       run();
+    }
+
+    public long getConnectedSinceNanos() {
+      return connectedSinceNanos;
+    }
+
+    public ConnectivityState getCurrentState() {
+      return currentState;
     }
 
     @Override
@@ -970,24 +1180,56 @@ public class GcpManagedChannel extends ManagedChannel {
       if (channel == null) {
         return;
       }
+
+      // Is the channel in the pool?
+      boolean isActive = channelRefs.contains(this.channelRef);
+
       // Keep minSize channels always connected.
-      boolean requestConnection = channelId < minSize;
+      boolean requestConnection =
+          channelRefs.size() < minSize
+              || channelRefs.stream()
+                  .mapToInt(ChannelRef::getId)
+                  .sorted()
+                  .limit(minSize)
+                  .anyMatch(id -> (id == channelRef.getId()));
+
       ConnectivityState newState = channel.getState(requestConnection);
-      logger.finer(
-          log("Channel %d state change detected: %s -> %s", channelId, currentState, newState));
-      if (newState == ConnectivityState.READY && currentState != ConnectivityState.READY) {
-        incReadyChannels();
-        saveReadinessTime(System.nanoTime() - connectingStartNanos);
+      if (logger.isLoggable(Level.FINER)) {
+        logger.finer(
+            log(
+                "Channel %d state change detected: %s -> %s",
+                channelRef.getId(), currentState, newState));
       }
-      if (newState != ConnectivityState.READY && currentState == ConnectivityState.READY) {
-        decReadyChannels();
+      if (newState == ConnectivityState.READY && currentState != ConnectivityState.READY) {
+        connectedSinceNanos = System.nanoTime();
+        if (isActive) {
+          incReadyChannels(true);
+          if (connectingStartNanos > 0) {
+            saveReadinessTime(System.nanoTime() - connectingStartNanos);
+          }
+        }
+        connectingStartNanos = 0;
+      }
+      if (isActive
+          && newState != ConnectivityState.READY
+          && currentState == ConnectivityState.READY) {
+        decReadyChannels(true);
       }
       if (newState == ConnectivityState.CONNECTING
           && currentState != ConnectivityState.CONNECTING) {
         connectingStartNanos = System.nanoTime();
       }
+      if (newState != ConnectivityState.READY) {
+        connectedSinceNanos = 0;
+      }
       currentState = newState;
-      processChannelStateChange(channelId, newState);
+
+      processChannelStateChange(channelRef.getId(), newState);
+      if (isActive) {
+        executeStateChangeCallbacks();
+      }
+
+      // Resubscribe.
       if (newState != ConnectivityState.SHUTDOWN) {
         channel.notifyWhenStateChanged(newState, this);
       }
@@ -1005,8 +1247,8 @@ public class GcpManagedChannel extends ManagedChannel {
     }
   }
 
+  @VisibleForTesting
   void processChannelStateChange(int channelId, ConnectivityState state) {
-    executeStateChangeCallbacks();
     if (!fallbackEnabled) {
       return;
     }
@@ -1074,7 +1316,7 @@ public class GcpManagedChannel extends ManagedChannel {
    * @return {@link ChannelRef}
    */
   protected synchronized ChannelRef getChannelRefRoundRobin() {
-    if (channelRefs.size() < maxSize) {
+    if (!isDynamicScalingEnabled && channelRefs.size() < maxSize) {
       return createNewChannel();
     }
     bindingIndex++;
@@ -1150,14 +1392,40 @@ public class GcpManagedChannel extends ManagedChannel {
     return mappedChannel;
   }
 
-  // Create a new channel and add it to channelRefs synchronously to make sure its id matches its
-  // channelRef's index.
-  private synchronized ChannelRef createNewChannel() {
-    final int size = channelRefs.size();
-    ChannelRef channelRef = new ChannelRef(delegateChannelBuilder.build(), size);
+  // Create a new channel and add it to channelRefs.
+  // If we have a ready channel not in the pool that we wait for completing its RPCs,
+  // then re-use that channel instead.
+  @VisibleForTesting
+  ChannelRef createNewChannel() {
+    Optional<ChannelRef> reusedChannelRef = pickChannelForReuse();
+    if (reusedChannelRef.isPresent()) {
+      ChannelRef chRef = reusedChannelRef.get();
+      channelRefs.add(chRef);
+      removedChannelRefs.remove(chRef);
+      logger.finer(log("Channel %d reused.", chRef.getId()));
+      incReadyChannels(false);
+      maxChannels = Math.max(maxChannels, channelRefs.size());
+      return chRef;
+    }
+
+    ChannelRef channelRef = new ChannelRef(delegateChannelBuilder.build());
     channelRefs.add(channelRef);
     logger.finer(log("Channel %d created.", channelRef.getId()));
+    maxChannels = Math.max(maxChannels, channelRefs.size());
     return channelRef;
+  }
+
+  private Optional<ChannelRef> pickChannelForReuse() {
+    // Pick the most recently connected, if any.
+    Optional<ChannelRef> chRef =
+        removedChannelRefs.stream().max(Comparator.comparing(ChannelRef::getConnectedSinceNanos));
+
+    // Make sure it is ready, because connectedSinceNanos may be 0.
+    if (chRef.isPresent() && chRef.get().getState() != ConnectivityState.READY) {
+      return Optional.empty();
+    }
+
+    return chRef;
   }
 
   // Returns first newly created channel or null if there are already some channels in the pool.
@@ -1189,6 +1457,19 @@ public class GcpManagedChannel extends ManagedChannel {
     return null;
   }
 
+  private boolean shouldScaleUp(int minStreams, int totalStreams) {
+    if (channelRefs.size() >= maxSize) {
+      // Pool is full.
+      return false;
+    }
+
+    if (!isDynamicScalingEnabled && minStreams >= maxConcurrentStreamsLowWatermark) {
+      return true;
+    }
+
+    return (isDynamicScalingEnabled && (totalStreams / channelRefs.size()) >= maxRpcPerChannel);
+  }
+
   /**
    * Pick a {@link ChannelRef} (and create a new one if necessary). If notReadyFallbackEnabled is
    * true in the {@link GcpResiliencyOptions} then instead of a channel in a non-READY state another
@@ -1208,33 +1489,40 @@ public class GcpManagedChannel extends ManagedChannel {
     ChannelRef readyCandidate = null;
     int readyMinStreams = Integer.MAX_VALUE;
 
+    int totalStreams = 0;
+
     for (ChannelRef channelRef : channelRefs) {
       int cnt = channelRef.getActiveStreamsCount();
+      totalStreams += cnt;
       if (cnt < minStreams) {
         minStreams = cnt;
         channelCandidate = channelRef;
       }
       if (cnt < readyMinStreams
           && !fallbackMap.containsKey(channelRef.getId())
-          && channelRef.getActiveStreamsCount() < DEFAULT_MAX_STREAM) {
+          && cnt < DEFAULT_MAX_STREAM) {
         readyMinStreams = cnt;
         readyCandidate = channelRef;
       }
     }
 
     if (!fallbackEnabled) {
-      if (channelRefs.size() < maxSize && minStreams >= maxConcurrentStreamsLowWatermark) {
+      // Check if we need to scale up.
+      if (shouldScaleUp(minStreams, totalStreams)) {
         ChannelRef newChannel = tryCreateNewChannel();
         if (newChannel != null) {
+          scaleUpCount++;
           return newChannel;
         }
       }
       return channelCandidate;
     }
 
-    if (channelRefs.size() < maxSize && readyMinStreams >= maxConcurrentStreamsLowWatermark) {
+    // Check if we need to scale up.
+    if (shouldScaleUp(readyMinStreams, totalStreams)) {
       ChannelRef newChannel = tryCreateNewChannel();
       if (newChannel != null) {
+        scaleUpCount++;
         if (!forFallback && readyCandidate == null) {
           if (logger.isLoggable(Level.FINEST)) {
             logger.finest(log("Fallback to newly created channel %d", newChannel.getId()));
@@ -1332,8 +1620,13 @@ public class GcpManagedChannel extends ManagedChannel {
         channelRef.getChannel().shutdownNow();
       }
     }
-    if (logMetricService != null && !logMetricService.isTerminated()) {
-      logMetricService.shutdownNow();
+    for (ChannelRef channelRef : removedChannelRefs) {
+      if (!channelRef.getChannel().isTerminated()) {
+        channelRef.getChannel().shutdownNow();
+      }
+    }
+    if (backgroundService != null && !backgroundService.isTerminated()) {
+      backgroundService.shutdownNow();
     }
     if (!stateNotificationExecutor.isTerminated()) {
       stateNotificationExecutor.shutdownNow();
@@ -1347,8 +1640,11 @@ public class GcpManagedChannel extends ManagedChannel {
     for (ChannelRef channelRef : channelRefs) {
       channelRef.getChannel().shutdown();
     }
-    if (logMetricService != null) {
-      logMetricService.shutdown();
+    for (ChannelRef channelRef : removedChannelRefs) {
+      channelRef.getChannel().shutdown();
+    }
+    if (backgroundService != null) {
+      backgroundService.shutdown();
     }
     stateNotificationExecutor.shutdown();
     return this;
@@ -1357,7 +1653,9 @@ public class GcpManagedChannel extends ManagedChannel {
   @Override
   public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
     long endTimeNanos = System.nanoTime() + unit.toNanos(timeout);
-    for (ChannelRef channelRef : channelRefs) {
+    List<ChannelRef> allChannelRefs = new ArrayList<>(channelRefs);
+    allChannelRefs.addAll(removedChannelRefs);
+    for (ChannelRef channelRef : allChannelRefs) {
       if (channelRef.getChannel().isTerminated()) {
         continue;
       }
@@ -1368,9 +1666,9 @@ public class GcpManagedChannel extends ManagedChannel {
       channelRef.getChannel().awaitTermination(awaitTimeNanos, NANOSECONDS);
     }
     long awaitTimeNanos = endTimeNanos - System.nanoTime();
-    if (logMetricService != null && awaitTimeNanos > 0) {
+    if (backgroundService != null && awaitTimeNanos > 0) {
       //noinspection ResultOfMethodCallIgnored
-      logMetricService.awaitTermination(awaitTimeNanos, NANOSECONDS);
+      backgroundService.awaitTermination(awaitTimeNanos, NANOSECONDS);
     }
     awaitTimeNanos = endTimeNanos - System.nanoTime();
     if (awaitTimeNanos > 0) {
@@ -1382,26 +1680,30 @@ public class GcpManagedChannel extends ManagedChannel {
 
   @Override
   public boolean isShutdown() {
-    for (ChannelRef channelRef : channelRefs) {
+    List<ChannelRef> allChannelRefs = new ArrayList<>(channelRefs);
+    allChannelRefs.addAll(removedChannelRefs);
+    for (ChannelRef channelRef : allChannelRefs) {
       if (!channelRef.getChannel().isShutdown()) {
         return false;
       }
     }
-    if (logMetricService != null) {
-      return logMetricService.isShutdown();
+    if (backgroundService != null && !backgroundService.isShutdown()) {
+      return false;
     }
     return stateNotificationExecutor.isShutdown();
   }
 
   @Override
   public boolean isTerminated() {
-    for (ChannelRef channelRef : channelRefs) {
+    List<ChannelRef> allChannelRefs = new ArrayList<>(channelRefs);
+    allChannelRefs.addAll(removedChannelRefs);
+    for (ChannelRef channelRef : allChannelRefs) {
       if (!channelRef.getChannel().isTerminated()) {
         return false;
       }
     }
-    if (logMetricService != null) {
-      return logMetricService.isTerminated();
+    if (backgroundService != null && !backgroundService.isTerminated()) {
+      return false;
     }
     return stateNotificationExecutor.isTerminated();
   }
@@ -1619,18 +1921,26 @@ public class GcpManagedChannel extends ManagedChannel {
     private final AtomicInteger deadlineExceededCount = new AtomicInteger();
     private final AtomicLong okCalls = new AtomicLong();
     private final AtomicLong errCalls = new AtomicLong();
+    private final ChannelStateMonitor channelStateMonitor;
 
-    protected ChannelRef(ManagedChannel channel, int channelId) {
-      this(channel, channelId, 0, 0);
+    protected ChannelRef(ManagedChannel channel) {
+      this(channel, 0, 0);
     }
 
-    protected ChannelRef(
-        ManagedChannel channel, int channelId, int affinityCount, int activeStreamsCount) {
+    protected ChannelRef(ManagedChannel channel, int affinityCount, int activeStreamsCount) {
       this.delegate = channel;
-      this.channelId = channelId;
+      this.channelId = nextChannelId.getAndIncrement();
       this.affinityCount = new AtomicInteger(affinityCount);
       this.activeStreamsCount = new AtomicInteger(activeStreamsCount);
-      new ChannelStateMonitor(channel, channelId);
+      channelStateMonitor = new ChannelStateMonitor(channel, this);
+    }
+
+    protected long getConnectedSinceNanos() {
+      return channelStateMonitor.getConnectedSinceNanos();
+    }
+
+    protected ConnectivityState getState() {
+      return channelStateMonitor.getCurrentState();
     }
 
     protected ManagedChannel getChannel() {
@@ -1653,6 +1963,10 @@ public class GcpManagedChannel extends ManagedChannel {
       totalAffinityCount.decrementAndGet();
     }
 
+    protected void resetAffinityCount() {
+      affinityCount.set(0);
+    }
+
     protected void activeStreamsCountIncr() {
       int actStreams = activeStreamsCount.incrementAndGet();
       if (maxActiveStreams < actStreams) {
@@ -1661,6 +1975,9 @@ public class GcpManagedChannel extends ManagedChannel {
       int totalActStreams = totalActiveStreams.incrementAndGet();
       if (maxTotalActiveStreams < totalActStreams) {
         maxTotalActiveStreams = totalActStreams;
+      }
+      if (maxTotalActiveStreamsForScaleDown < totalActStreams) {
+        maxTotalActiveStreamsForScaleDown = totalActStreams;
       }
     }
 

--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpMetricsConstants.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpMetricsConstants.java
@@ -36,12 +36,18 @@ class GcpMetricsConstants {
   public static String TYPE_FALLBACK = "FALLBACK";
   public static String TYPE_RECOVER = "RECOVER";
   public static String TYPE_REPLACE = "REPLACE";
+  public static String DIRECTION_LABEL = "direction";
+  public static String DIRECTION_LABEL_DESC = "Direction (up/down).";
+  public static String DIRECTION_UP = "UP";
+  public static String DIRECTION_DOWN = "DOWN";
 
   // Unit to represent count.
   static final String COUNT = "1";
   static final String MICROSECOND = "us";
   static final String MILLISECOND = "ms";
 
+  public static String METRIC_NUM_CHANNELS = "num_channels";
+  public static String METRIC_MIN_CHANNELS = "min_channels";
   public static String METRIC_MAX_CHANNELS = "max_channels";
   public static String METRIC_MIN_READY_CHANNELS = "min_ready_channels";
   public static String METRIC_MAX_READY_CHANNELS = "max_ready_channels";
@@ -70,4 +76,5 @@ class GcpMetricsConstants {
   public static String METRIC_ENDPOINT_STATE = "endpoint_state";
   public static String METRIC_ENDPOINT_SWITCH = "endpoint_switch";
   public static String METRIC_CURRENT_ENDPOINT = "current_endpoint";
+  public static String METRIC_CHANNEL_POOL_SCALING = "channel_pool_scaling";
 }

--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpMultiEndpointChannel.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpMultiEndpointChannel.java
@@ -494,8 +494,7 @@ public class GcpMultiEndpointChannel extends ManagedChannel {
     if (!poolsToRemove.isEmpty()) {
       // Get max switching delay.
       Optional<Duration> maxDelay =
-          meOptions
-              .stream()
+          meOptions.stream()
               .map(GcpMultiEndpointOptions::getSwitchingDelay)
               .max(Comparator.naturalOrder());
       if (maxDelay.isPresent() && maxDelay.get().toMillis() > 0) {

--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/multiendpoint/MultiEndpoint.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/multiendpoint/MultiEndpoint.java
@@ -149,9 +149,7 @@ public final class MultiEndpoint {
   }
 
   public List<String> getEndpoints() {
-    return endpointsMap
-        .values()
-        .stream()
+    return endpointsMap.values().stream()
         .sorted(comparingInt(Endpoint::getPriority))
         .map(Endpoint::getId)
         .collect(Collectors.toList());
@@ -216,9 +214,7 @@ public final class MultiEndpoint {
   // recovering.
   synchronized void maybeUpdateCurrentEndpoint() {
     Optional<Endpoint> topEndpoint =
-        endpointsMap
-            .values()
-            .stream()
+        endpointsMap.values().stream()
             .filter((c) -> c.getState().equals(EndpointState.AVAILABLE))
             .min(comparingInt(Endpoint::getPriority));
 

--- a/grpc-gcp/src/test/java/com/google/cloud/grpc/GcpManagedChannelTest.java
+++ b/grpc-gcp/src/test/java/com/google/cloud/grpc/GcpManagedChannelTest.java
@@ -56,8 +56,11 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -65,10 +68,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -1550,12 +1556,209 @@ public final class GcpManagedChannelTest {
     assertThat(pool.affinityKeyLastUsed.get(expKey)).isNull();
   }
 
+  @Test
+  public void testDynamicChannelPool() throws InterruptedException {
+
+    final int minSize = 2;
+    final int maxSize = 4;
+    final int minRpcPerChannel = 2;
+    final int maxRpcPerChannel = 5;
+    final Duration scaleDownInterval = Duration.ofMillis(50);
+    final ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+    FakeManagedChannelBuilder fmcb = new FakeManagedChannelBuilder(() -> new FakeManagedChannel(executorService));
+
+    // Creating a pool with dynamic sizing.
+    final GcpManagedChannel pool =
+        (GcpManagedChannel)
+            GcpManagedChannelBuilder.forDelegateBuilder(fmcb)
+                .withOptions(
+                    GcpManagedChannelOptions.newBuilder()
+                        .withChannelPoolOptions(
+                            GcpChannelPoolOptions.newBuilder()
+                                .setMinSize(minSize)
+                                .setMaxSize(maxSize)
+                                .setDynamicScaling(minRpcPerChannel, maxRpcPerChannel, scaleDownInterval)
+                                .build())
+                        .build())
+                .build();
+
+    // Starts with minSize.
+    assertThat(pool.getNumberOfChannels()).isEqualTo(minSize);
+
+    // Mark connected in random order.
+    List<ChannelRef> shuffled = new ArrayList<>(pool.channelRefs);
+    Collections.shuffle(shuffled);
+    for (ChannelRef channelRef : shuffled) {
+      ((FakeManagedChannel) channelRef.getChannel()).setState(ConnectivityState.READY);
+    }
+
+    long startTime = System.nanoTime();
+
+    // Simulate starting 10 calls which should be within the limit (2 channels x 5 maxRpcPerChannel).
+    for (int i = 0; i < minSize*maxRpcPerChannel; i++) {
+      pool.getChannelRef(null).activeStreamsCountIncr();
+    }
+
+    // As we are still within threshold of maxRpcPerChannel the pool must not scale yet.
+    assertThat(pool.getNumberOfChannels()).isEqualTo(minSize);
+
+    // Adding 11th call should trigger scaling up immediately.
+    pool.getChannelRef(null).activeStreamsCountIncr();
+    assertThat(pool.getNumberOfChannels()).isEqualTo(minSize+1);
+
+    // Mark newly created channel connected.
+    ((FakeManagedChannel) pool.channelRefs.get(minSize).getChannel()).setState(ConnectivityState.READY);
+
+    // Continue adding calls to verify the pool respects the maxSize value.
+    for (int i = 0; i < maxSize*maxRpcPerChannel-minSize*maxRpcPerChannel; i++) {
+      pool.getChannelRef(null).activeStreamsCountIncr();
+    }
+
+    // Now we have 21 calls in-flight which should bring us to 5 channels because
+    // of maxRpcPerChannel is 5, but the max size of the pool is 4, so there should be 4 channels.
+    assertThat(pool.getNumberOfChannels()).isEqualTo(maxSize);
+
+    // Threshold for scaling down is minRpcPerChannel * number of channels. 2 * 3 in our case.
+    // Going down 21 -> 7.
+    for (ChannelRef channelRef : pool.channelRefs) {
+      for (int i = 0; i < maxRpcPerChannel-minRpcPerChannel; i++) {
+        channelRef.activeStreamsCountDecr(startTime, Status.OK, false);
+      }
+    }
+    for (int i = 0; i < minRpcPerChannel; i++) {
+      pool.channelRefs.get(i).activeStreamsCountDecr(startTime, Status.OK, false);
+    }
+
+    // Should not downscale yet.
+    assertThat(pool.getNumberOfChannels()).isEqualTo(maxSize);
+
+    // Should not downscale even after scale down check is passed.
+    TimeUnit.MILLISECONDS.sleep(2 * scaleDownInterval.toMillis());
+    assertThat(pool.getNumberOfChannels()).isEqualTo(maxSize);
+    
+    // Set all except last channel ready.
+    for (int i = 0; i < pool.getNumberOfChannels(); i++) {
+      if (i == pool.getNumberOfChannels() - 1) {
+        continue;
+      }
+      ((FakeManagedChannel) pool.channelRefs.get(i).getChannel()).setState(ConnectivityState.READY);
+    }
+
+    // Remember not connected channel or oldest connected channel. In our case the last one (not connected yet).
+    final ChannelRef disconnectedRef = pool.channelRefs.stream().min(Comparator.comparing(
+        (GcpManagedChannel.ChannelRef chRef) -> chRef.getConnectedSinceNanos())).get();
+
+    // Removing one more stream should trigger scale down after the interval.
+    pool.channelRefs.get(0).activeStreamsCountDecr(startTime, Status.OK, false);
+    TimeUnit.MILLISECONDS.sleep(2 * scaleDownInterval.toMillis());
+    assertThat(pool.getNumberOfChannels()).isEqualTo(maxSize - 1);
+
+    // Make sure the oldest connected channel is removed.
+    assertThat(pool.channelRefs.stream().anyMatch((chRef) -> (chRef == disconnectedRef))).isFalse();
+
+    Set<ChannelRef> prevChannels = new HashSet<>(pool.channelRefs);
+
+    // Scale up again to make sure not connected channels are not reused.
+    for (int i = 0; i < 2 * maxRpcPerChannel + disconnectedRef.getActiveStreamsCount(); i++) {
+      pool.getChannelRef(null).activeStreamsCountIncr();
+    }
+
+    assertThat(pool.getNumberOfChannels()).isEqualTo(maxSize);
+
+    // Find newly created channel.
+    ChannelRef newChannel = pool.channelRefs.stream().dropWhile(chRef -> prevChannels.contains(chRef)).findFirst().get();
+    // Mark ready.
+    ((FakeManagedChannel) newChannel.getChannel()).setState(ConnectivityState.READY);
+
+    // Make sure disconnectedRef is not reused.
+    assertThat(newChannel == disconnectedRef).isFalse();
+
+    // Make sure previously removed channel is not shutted down as it still has a couple of calls.
+    assertThat(disconnectedRef.getState()).isNotEqualTo(ConnectivityState.SHUTDOWN);
+
+    // Cancel the calls and make sure the channel shutdown.
+    while (disconnectedRef.getActiveStreamsCount() > 0) {
+      disconnectedRef.activeStreamsCountDecr(startTime, Status.CANCELLED, true);
+    }
+    TimeUnit.MILLISECONDS.sleep(2 * scaleDownInterval.toMillis());
+    assertThat(disconnectedRef.getChannel().getState(false)).isEqualTo(ConnectivityState.SHUTDOWN);
+
+    // Find the oldest connected channel.
+    ChannelRef oldestConnected = pool.channelRefs.stream().sorted(Comparator.comparing(
+      (GcpManagedChannel.ChannelRef chRef) -> chRef.getConnectedSinceNanos())).findFirst().get();
+    // Remember its streams count.
+    int oldestStreamsCount = oldestConnected.getActiveStreamsCount();
+
+    // Scale down. Desired state: minRpcPerChannel on every channel, then closing minRpcPerChannel streams cycling through channels.
+    for (ChannelRef channelRef : pool.channelRefs) {
+      while (channelRef.getActiveStreamsCount() != minRpcPerChannel) {
+        if (channelRef.getActiveStreamsCount() > minRpcPerChannel) {
+          channelRef.activeStreamsCountDecr(startTime, Status.OK, false);
+        } else {
+          channelRef.activeStreamsCountIncr();
+        }
+      }
+    }
+    for (int i = 0; i < minRpcPerChannel; i++) {
+      pool.channelRefs.get(i).activeStreamsCountDecr(startTime, Status.OK, false);
+    }
+    TimeUnit.MILLISECONDS.sleep(2 * scaleDownInterval.toMillis());
+    assertThat(pool.getNumberOfChannels()).isEqualTo(maxSize - 1);
+
+    // Make sure it is removed.
+    assertThat(pool.channelRefs.stream().anyMatch(chRef -> chRef == oldestConnected)).isFalse();
+
+    // The active streams should still be there.
+    assertThat(oldestConnected.getActiveStreamsCount()).isEqualTo(oldestStreamsCount);
+
+    // The removed oldest connected channel must still be ready.
+    assertThat(oldestConnected.getState()).isEqualTo(ConnectivityState.READY);
+
+    // Scale up.
+    for (int i = 0; i < 2 * maxRpcPerChannel + oldestConnected.getActiveStreamsCount(); i++) {
+      pool.getChannelRef(null).activeStreamsCountIncr();
+    }
+    assertThat(pool.getNumberOfChannels()).isEqualTo(maxSize);
+
+    // Make sure it is reused.
+    assertThat(pool.channelRefs.stream().anyMatch(chRef -> chRef == oldestConnected)).isTrue();
+
+    // Remember maxSize-minSize oldest connected channels.
+    List<ChannelRef> oldestConnectedChannels = pool.channelRefs.stream().sorted(Comparator.comparing(
+      (GcpManagedChannel.ChannelRef chRef) -> chRef.getConnectedSinceNanos())).collect(Collectors.toList()).subList(0, maxSize-minSize);
+
+    // Remove all streams so that channel pool downscales to minSize.
+    for (ChannelRef channelRef : pool.channelRefs) {
+      while (channelRef.getActiveStreamsCount() > 0) {
+        channelRef.activeStreamsCountDecr(startTime, Status.OK, false);
+      }
+    }
+
+    // Make sure channel pool scaled down to minSize after the interval.
+    TimeUnit.MILLISECONDS.sleep(2 * scaleDownInterval.toMillis());
+    assertThat(pool.getNumberOfChannels()).isEqualTo(minSize);
+
+    // Make sure the oldest connected channels were removed.
+    assertThat(pool.channelRefs.stream().anyMatch(chRef -> oldestConnectedChannels.contains(chRef))).isFalse();
+
+    // Make sure the removed channels are shutted down.
+    assertThat(oldestConnectedChannels.stream().allMatch(chRef -> chRef.getState() == ConnectivityState.SHUTDOWN)).isTrue();
+  }
+
   static class FakeManagedChannelBuilder extends ManagedChannelBuilder<FakeManagedChannelBuilder> {
     private final List<? extends ManagedChannel> channels;
+    private final Supplier<? extends ManagedChannel> channelFactory;
     private final AtomicInteger next = new AtomicInteger();
 
     FakeManagedChannelBuilder(List<? extends ManagedChannel> channels) {
       this.channels = channels;
+      this.channelFactory = null;
+    }
+
+    FakeManagedChannelBuilder(Supplier<? extends ManagedChannel> channelFactory) {
+      this.channelFactory = channelFactory;
+      this.channels = null;
     }
 
     @Override
@@ -1610,7 +1813,11 @@ public final class GcpManagedChannelTest {
 
     @Override
     public ManagedChannel build() {
-      return channels.get(next.getAndIncrement());
+      if (channels != null) {
+        return channels.get(next.getAndIncrement());
+      }
+
+      return channelFactory.get();
     }
   }
 
@@ -1653,27 +1860,35 @@ public final class GcpManagedChannelTest {
 
     @Override
     public ManagedChannel shutdown() {
+      this.setState(ConnectivityState.SHUTDOWN);
       return null;
     }
 
     @Override
     public boolean isShutdown() {
-      return false;
+      return this.state == ConnectivityState.SHUTDOWN;
     }
 
     @Override
     public boolean isTerminated() {
-      return false;
+      return this.state == ConnectivityState.SHUTDOWN;
     }
 
     @Override
     public ManagedChannel shutdownNow() {
+      this.setState(ConnectivityState.SHUTDOWN);
       return null;
     }
 
     @Override
     public boolean awaitTermination(long timeout, TimeUnit unit) {
-      return false;
+      if (this.state == ConnectivityState.SHUTDOWN) {
+        return true;
+      }
+      try {
+        unit.sleep(timeout);
+      } catch (InterruptedException e) {}
+      return this.state == ConnectivityState.SHUTDOWN;
     }
 
     @Override

--- a/grpc-gcp/src/test/java/com/google/cloud/grpc/SpannerIntegrationTest.java
+++ b/grpc-gcp/src/test/java/com/google/cloud/grpc/SpannerIntegrationTest.java
@@ -668,8 +668,7 @@ public final class SpannerIntegrationTest {
 
     // Make sure endpoint is set as a metric label for each pool.
     assertThat(
-            logRecords
-                .stream()
+            logRecords.stream()
                 .filter(
                     logRecord ->
                         logRecord
@@ -688,8 +687,7 @@ public final class SpannerIntegrationTest {
         .isEqualTo(1);
 
     assertThat(
-            logRecords
-                .stream()
+            logRecords.stream()
                 .filter(
                     logRecord ->
                         logRecord
@@ -765,8 +763,7 @@ public final class SpannerIntegrationTest {
 
     // Make sure there were 3 session creation requests in the leader pool only.
     assertThat(
-            logRecords
-                .stream()
+            logRecords.stream()
                 .filter(
                     logRecord ->
                         logRecord
@@ -777,8 +774,7 @@ public final class SpannerIntegrationTest {
         .isEqualTo(3);
 
     assertThat(
-            logRecords
-                .stream()
+            logRecords.stream()
                 .filter(
                     logRecord ->
                         logRecord


### PR DESCRIPTION
Provides dynamic scaling functionality which is configured with three parameters:
- minRpcPerChannel -- minimum desired average concurrent calls per channel.
- maxRpcPerChannel -- maximum desired average concurrent calls per channel.
- scaleDownInterval -- how often to check for a possibility to scale down.

When the average number of concurrent calls per channel reaches `maxRpcPerChannel` the pool will create and add a new channel unless already at max size.

Every `scaleDownInterval` a check for downscaling is performed. Based on the maximum total concurrent calls observed since the last check, the desired number of channels is calculated as:

`(max_total_concurrent_calls / minRpcPerChannel)` rounded up.

If the calculated desired number of channels is lower than the current number of channels, the pool will be downscaled to the desired number or min size (whichever is greater).

When downscaling, channels with the oldest connections are selected. Then the selected channels are removed from the pool but are not instructed to shutdown until all calls are completed. In a case when the pool is scaling up and there is a ready channel awaiting calls completion, the channel will be re-used instead of creating a new channel.