### PR TITLE
fix: unbind manual affinity keys after terminal calls

### DIFF
--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpClientCall.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpClientCall.java
@@ -27,6 +27,7 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -222,17 +223,24 @@ public class GcpClientCall<ReqT, RespT> extends ClientCall<ReqT, RespT> {
    */
   public static class SimpleGcpClientCall<ReqT, RespT> extends ForwardingClientCall<ReqT, RespT> {
 
+    private final GcpManagedChannel delegateChannel;
     private final GcpManagedChannel.ChannelRef channelRef;
     private final ClientCall<ReqT, RespT> delegateCall;
+    @Nullable private final String affinityKey;
+    private final boolean unbindOnComplete;
     private long startNanos = 0;
 
     private final AtomicBoolean decremented = new AtomicBoolean(false);
 
     protected SimpleGcpClientCall(
+        GcpManagedChannel delegateChannel,
         GcpManagedChannel.ChannelRef channelRef,
         MethodDescriptor<ReqT, RespT> methodDescriptor,
         CallOptions callOptions) {
+      this.delegateChannel = delegateChannel;
       this.channelRef = channelRef;
+      this.affinityKey = callOptions.getOption(GcpManagedChannel.AFFINITY_KEY);
+      this.unbindOnComplete = callOptions.getOption(GcpManagedChannel.UNBIND_AFFINITY_KEY);
       // Set the actual channel ID in callOptions so downstream interceptors can access it.
       CallOptions callOptionsWithChannelId =
           callOptions.withOption(GcpManagedChannel.CHANNEL_ID_KEY, channelRef.getId());
@@ -257,6 +265,12 @@ public class GcpClientCall<ReqT, RespT> extends ClientCall<ReqT, RespT> {
               if (!decremented.getAndSet(true)) {
                 channelRef.activeStreamsCountDecr(startNanos, status, false);
               }
+              // Unbind the affinity key when the caller explicitly requests it
+              // (e.g., on terminal RPCs like Commit or Rollback) to prevent
+              // unbounded growth of the affinity map.
+              if (unbindOnComplete && affinityKey != null) {
+                delegateChannel.unbind(Collections.singletonList(affinityKey));
+              }
               super.onClose(status, trailers);
             }
 
@@ -275,6 +289,10 @@ public class GcpClientCall<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     public void cancel(String message, Throwable cause) {
       if (!decremented.getAndSet(true)) {
         channelRef.activeStreamsCountDecr(startNanos, Status.CANCELLED, true);
+      }
+      // Always unbind on cancel — the transaction is being abandoned.
+      if (affinityKey != null) {
+        delegateChannel.unbind(Collections.singletonList(affinityKey));
       }
       delegateCall.cancel(message, cause);
     }

--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannel.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannel.java
@@ -93,6 +93,7 @@ public class GcpManagedChannel extends ManagedChannel {
       CallOptions.Key.createWithDefault("DisableAffinity", false);
   public static final Context.Key<String> AFFINITY_CTX_KEY = Context.key("AffinityKey");
   public static final CallOptions.Key<String> AFFINITY_KEY = CallOptions.Key.create("AffinityKey");
+
   /** When set to true, the affinity key will be unbound after the call completes. */
   public static final CallOptions.Key<Boolean> UNBIND_AFFINITY_KEY =
       CallOptions.Key.createWithDefault("UnbindAffinityKey", false);

--- a/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannel.java
+++ b/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannel.java
@@ -93,6 +93,9 @@ public class GcpManagedChannel extends ManagedChannel {
       CallOptions.Key.createWithDefault("DisableAffinity", false);
   public static final Context.Key<String> AFFINITY_CTX_KEY = Context.key("AffinityKey");
   public static final CallOptions.Key<String> AFFINITY_KEY = CallOptions.Key.create("AffinityKey");
+  /** When set to true, the affinity key will be unbound after the call completes. */
+  public static final CallOptions.Key<Boolean> UNBIND_AFFINITY_KEY =
+      CallOptions.Key.createWithDefault("UnbindAffinityKey", false);
 
   /**
    * CallOptions key that will be set by grpc-gcp with the actual channel ID used for the call. This
@@ -1848,7 +1851,7 @@ public class GcpManagedChannel extends ManagedChannel {
         logger.finest(log("Channel affinity is disabled via context or call options."));
       }
       return new GcpClientCall.SimpleGcpClientCall<>(
-          getChannelRef(null), methodDescriptor, callOptions);
+          this, getChannelRef(null), methodDescriptor, callOptions);
     }
 
     AffinityConfig affinity = methodToAffinity.get(methodDescriptor.getFullMethodName());
@@ -1858,7 +1861,7 @@ public class GcpManagedChannel extends ManagedChannel {
     }
 
     return new GcpClientCall.SimpleGcpClientCall<>(
-        getChannelRef(key), methodDescriptor, callOptions);
+        this, getChannelRef(key), methodDescriptor, callOptions);
   }
 
   @Nullable

--- a/grpc-gcp/src/test/java/com/google/cloud/grpc/GcpClientCallTest.java
+++ b/grpc-gcp/src/test/java/com/google/cloud/grpc/GcpClientCallTest.java
@@ -105,8 +105,8 @@ public final class GcpClientCallTest {
     call.start(new ClientCall.Listener<String>() {}, new Metadata());
 
     ArgumentCaptor<ClientCall.Listener<String>> listenerCaptor =
-        (ArgumentCaptor<ClientCall.Listener<String>>) (ArgumentCaptor<?>)
-            ArgumentCaptor.forClass(ClientCall.Listener.class);
+        (ArgumentCaptor<ClientCall.Listener<String>>)
+            (ArgumentCaptor<?>) ArgumentCaptor.forClass(ClientCall.Listener.class);
     verify(delegateCall).start(listenerCaptor.capture(), any(Metadata.class));
 
     assertThat(gcpChannel.affinityKeyToChannelRef).containsKey(affinityKey);
@@ -133,8 +133,8 @@ public final class GcpClientCallTest {
     call.start(new ClientCall.Listener<String>() {}, new Metadata());
 
     ArgumentCaptor<ClientCall.Listener<String>> listenerCaptor =
-        (ArgumentCaptor<ClientCall.Listener<String>>) (ArgumentCaptor<?>)
-            ArgumentCaptor.forClass(ClientCall.Listener.class);
+        (ArgumentCaptor<ClientCall.Listener<String>>)
+            (ArgumentCaptor<?>) ArgumentCaptor.forClass(ClientCall.Listener.class);
     verify(delegateCall).start(listenerCaptor.capture(), any(Metadata.class));
 
     listenerCaptor.getValue().onClose(Status.OK, new Metadata());

--- a/grpc-gcp/src/test/java/com/google/cloud/grpc/GcpClientCallTest.java
+++ b/grpc-gcp/src/test/java/com/google/cloud/grpc/GcpClientCallTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.grpc;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.ConnectivityState;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import java.io.InputStream;
+import java.util.Collections;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class GcpClientCallTest {
+
+  private static final class FakeMarshaller<T> implements MethodDescriptor.Marshaller<T> {
+    @Override
+    public InputStream stream(T value) {
+      return null;
+    }
+
+    @Override
+    public T parse(InputStream stream) {
+      return null;
+    }
+  }
+
+  private static final MethodDescriptor<String, String> METHOD_DESCRIPTOR =
+      MethodDescriptor.<String, String>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("test/method")
+          .setRequestMarshaller(new FakeMarshaller<>())
+          .setResponseMarshaller(new FakeMarshaller<>())
+          .build();
+
+  @Mock private ManagedChannel delegateChannel;
+  @Mock private ClientCall<String, String> delegateCall;
+
+  private GcpManagedChannel gcpChannel;
+  private GcpManagedChannel.ChannelRef channelRef;
+
+  @Before
+  public void setUp() {
+    ManagedChannelBuilder<?> builder = ManagedChannelBuilder.forAddress("localhost", 443);
+    gcpChannel = (GcpManagedChannel) GcpManagedChannelBuilder.forDelegateBuilder(builder).build();
+
+    when(delegateChannel.getState(anyBoolean())).thenReturn(ConnectivityState.IDLE);
+    when(delegateChannel.newCall(eq(METHOD_DESCRIPTOR), any(CallOptions.class)))
+        .thenReturn(delegateCall);
+
+    channelRef = gcpChannel.new ChannelRef(delegateChannel);
+  }
+
+  @After
+  public void tearDown() {
+    gcpChannel.shutdownNow();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void simpleCallUnbindsAffinityKeyOnCloseWhenRequested() {
+    String affinityKey = "txn-1";
+    gcpChannel.bind(channelRef, Collections.singletonList(affinityKey));
+
+    GcpClientCall.SimpleGcpClientCall<String, String> call =
+        new GcpClientCall.SimpleGcpClientCall<>(
+            gcpChannel,
+            channelRef,
+            METHOD_DESCRIPTOR,
+            CallOptions.DEFAULT
+                .withOption(GcpManagedChannel.AFFINITY_KEY, affinityKey)
+                .withOption(GcpManagedChannel.UNBIND_AFFINITY_KEY, true));
+
+    call.start(new ClientCall.Listener<String>() {}, new Metadata());
+
+    ArgumentCaptor<ClientCall.Listener<String>> listenerCaptor =
+        (ArgumentCaptor<ClientCall.Listener<String>>) (ArgumentCaptor<?>)
+            ArgumentCaptor.forClass(ClientCall.Listener.class);
+    verify(delegateCall).start(listenerCaptor.capture(), any(Metadata.class));
+
+    assertThat(gcpChannel.affinityKeyToChannelRef).containsKey(affinityKey);
+
+    listenerCaptor.getValue().onClose(Status.OK, new Metadata());
+
+    assertThat(gcpChannel.affinityKeyToChannelRef).doesNotContainKey(affinityKey);
+    assertThat(channelRef.getAffinityCount()).isEqualTo(0);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void simpleCallKeepsAffinityKeyOnCloseWhenUnbindNotRequested() {
+    String affinityKey = "txn-2";
+    gcpChannel.bind(channelRef, Collections.singletonList(affinityKey));
+
+    GcpClientCall.SimpleGcpClientCall<String, String> call =
+        new GcpClientCall.SimpleGcpClientCall<>(
+            gcpChannel,
+            channelRef,
+            METHOD_DESCRIPTOR,
+            CallOptions.DEFAULT.withOption(GcpManagedChannel.AFFINITY_KEY, affinityKey));
+
+    call.start(new ClientCall.Listener<String>() {}, new Metadata());
+
+    ArgumentCaptor<ClientCall.Listener<String>> listenerCaptor =
+        (ArgumentCaptor<ClientCall.Listener<String>>) (ArgumentCaptor<?>)
+            ArgumentCaptor.forClass(ClientCall.Listener.class);
+    verify(delegateCall).start(listenerCaptor.capture(), any(Metadata.class));
+
+    listenerCaptor.getValue().onClose(Status.OK, new Metadata());
+
+    assertThat(gcpChannel.affinityKeyToChannelRef).containsEntry(affinityKey, channelRef);
+    assertThat(channelRef.getAffinityCount()).isEqualTo(1);
+  }
+
+  @Test
+  public void simpleCallUnbindsAffinityKeyOnCancel() {
+    String affinityKey = "txn-3";
+    gcpChannel.bind(channelRef, Collections.singletonList(affinityKey));
+
+    GcpClientCall.SimpleGcpClientCall<String, String> call =
+        new GcpClientCall.SimpleGcpClientCall<>(
+            gcpChannel,
+            channelRef,
+            METHOD_DESCRIPTOR,
+            CallOptions.DEFAULT.withOption(GcpManagedChannel.AFFINITY_KEY, affinityKey));
+
+    call.start(new ClientCall.Listener<String>() {}, new Metadata());
+    call.cancel("cancelled", null);
+
+    assertThat(gcpChannel.affinityKeyToChannelRef).doesNotContainKey(affinityKey);
+    assertThat(channelRef.getAffinityCount()).isEqualTo(0);
+    verify(delegateCall).cancel("cancelled", null);
+  }
+}


### PR DESCRIPTION

  This change prevents manual affinity keys from accumulating in grpc-gcp’s affinity map for terminal transaction RPCs.

  ## What changed

  - added `UNBIND_AFFINITY_KEY` to `GcpManagedChannel` call options
  - updated `SimpleGcpClientCall` to unbind the manual affinity key on successful completion when that option is set
  - updated `SimpleGcpClientCall` to always unbind the manual affinity key on cancel
  - added unit tests covering:
    - unbind on close when requested
    - no unbind on close when not requested
    - unbind on cancel

  ## Why

  Java Spanner dynamic channel pooling already configures affinity cleanup with:
  - affinity key lifetime: 10 minutes
  - cleanup interval: 1 minute

  That cleanup is time-based, so terminal RPCs such as commit or rollback could still leave manual affinity keys in the map until the cleanup task ran. This change makes cleanup immediate for explicit terminal flows, preventing unnecessary growth of the affinity map and reducing stale channel stickiness for abandoned or completed transactions.

  ## Impact

  - no direct change to dynamic pool scale-up or scale-down behavior
  - improves affinity cleanup for manually assigned keys
  - allows future calls for the same key to rebalance normally after terminal completion or cancellation instead of waiting for periodic cleanup
